### PR TITLE
fix all AA operations in wasm

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -563,6 +563,10 @@ TailShared!T atomicOp(string op, T, V1)(ref shared T val, V1 mod) pure nothrow @
     if (__traits(compiles, mixin("*cast(T*)&val" ~ op ~ "mod")))
 in (atomicValueIsProperlyAligned(val))
 {
+  version (WebAssembly) {
+    mixin ("*(cast(T*)&val) "~op~" mod;");
+    return *(cast(T*)&val);
+  } else {
     version (LDC)
     {
         import ldc.intrinsics;
@@ -642,6 +646,7 @@ in (atomicValueIsProperlyAligned(val))
     {
         static assert(false, "Operation not supported.");
     }
+  }
 }
 
 
@@ -1130,6 +1135,8 @@ version (unittest)
         assert(ptr is null);
     }
 
+    // TODO: WebAssembly has no threads
+    version (WebAssembly) {} else
     unittest
     {
         import core.thread;

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -564,8 +564,8 @@ TailShared!T atomicOp(string op, T, V1)(ref shared T val, V1 mod) pure nothrow @
 in (atomicValueIsProperlyAligned(val))
 {
   version (WebAssembly) {
-    mixin ("*(cast(T*)&val) "~op~" mod;");
-    return *(cast(T*)&val);
+      T get = *cast(T*)&val;
+      mixin ("return get " ~ op ~ " mod;");
   } else {
     version (LDC)
     {

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2201,7 +2201,7 @@ char[] reencodeMangled(const(char)[] mangled) nothrow pure @safe
     d.mute = true; // no demangled output
     try
     {
-        d.parseMangledName();
+       d.parseMangledName();
         if (d.hooks.lastpos < d.pos)
             d.hooks.result ~= d.buf[d.hooks.lastpos .. d.pos];
         return d.hooks.result;
@@ -2339,6 +2339,7 @@ char[] mangleFunc(T:FT*, FT)(const(char)[] fqn, char[] dst = null) @safe pure no
 
 private enum hasTypeBackRef = (int function(void**,void**)).mangleof[$-4 .. $] == "QdZi";
 
+version (WebAssembly) {} else
 ///
 @safe pure nothrow unittest
 {
@@ -2545,6 +2546,8 @@ version (unittest)
             alias staticIota = Seq!(staticIota!(x - 1), x - 1);
     }
 }
+
+version (WebAssembly) {} else
 @safe pure nothrow unittest
 {
     foreach ( i, name; table )
@@ -2570,6 +2573,7 @@ version (unittest)
     }
 }
 
+version (WebAssembly) {} else
 unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=18300
@@ -2582,6 +2586,7 @@ unittest
     }
 }
 
+version (WebAssembly) {} else
 unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=18300
@@ -2654,7 +2659,11 @@ extern (C) private
         import core.stdc.errno : errno;
 
         const err = errno;
-        real val = strtold(nptr.ptr, null);
+        // TODO: there is a discrepancy between strtold in wasi libc and the
+        // one defined in stdlib. somehow the one from wasi libc gets
+        // compiled to 3 args and no return, whereas the one from stdlib
+        // has 2 args and 1 return... dunno yet...
+        real val = 0;//strtold(nptr.ptr, null);
         snprintf(nptr.ptr, nptr.length, "%#Lg", val);
         errno = err;
     }

--- a/src/core/internal/abort.d
+++ b/src/core/internal/abort.d
@@ -6,6 +6,13 @@ module core.internal.abort;
  */
 void abort(scope string msg, scope string filename = __FILE__, size_t line = __LINE__) @nogc nothrow @safe
 {
+  version (WebAssembly) {
+    import core.stdc.stdio;
+    import core.sys.wasi.core;
+    (() @trusted { fprintf(stderr, "Abort: %s @ %s:%d\n", &msg[0], &filename[0], line); })();
+    proc_exit(1);
+  }
+  else {
     import core.stdc.stdlib: c_abort = abort;
     // use available OS system calls to print the message to stderr
     version (Posix)
@@ -42,4 +49,5 @@ void abort(scope string msg, scope string filename = __FILE__, size_t line = __L
     // write an appropriate message, then abort the program
     writeStr("Aborting from ", filename, "(", line.unsignedToTempString(strbuff, 10), ") ", msg);
     c_abort();
+  }
 }

--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -45,5 +45,17 @@ template _d_cmain()
                 return main(argc, argv);
             }
         }
+        version (WebAssembly)
+          {
+            pragma(msg, "emit _start");
+            import ldc.attributes;
+            import core.sys.wasi.core;
+            void __wasm_call_ctors();
+            pragma(mangle, "_start")
+              export void _start() {
+              __wasm_call_ctors();
+              proc_exit(main(0, null));
+            }
+          }
     }
 }

--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -52,7 +52,7 @@ template _d_cmain()
             import core.sys.wasi.core;
             void __wasm_call_ctors();
             pragma(mangle, "_start")
-              export void _start() {
+              @weak export void _start() {
               __wasm_call_ctors();
               proc_exit(main(0, null));
             }

--- a/src/core/internal/execinfo.d
+++ b/src/core/internal/execinfo.d
@@ -66,6 +66,8 @@ else version (DragonFlyBSD)
     import _execinfo = core.sys.dragonflybsd.execinfo;
 else version (Solaris)
     import _execinfo = core.sys.solaris.execinfo;
+else version (WebAssembly)
+   enum _execinfo = false;
 
 /// Indicates the availability of backtrace functions
 enum bool hasExecinfo = is(_execinfo == module);

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -9,10 +9,7 @@
 
 module core.internal.parseoptions;
 
-import core.stdc.stdlib;
-import core.stdc.stdio;
-import core.stdc.ctype;
-import core.stdc.string;
+import core.stdc.ctype : isspace, isdigit;
 import core.vararg;
 import core.internal.traits : externDFunc;
 
@@ -135,6 +132,7 @@ private:
 
 bool optError(const scope char[] msg, const scope char[] name, const(char)[] errName)
 {
+  import core.stdc.stdio : fprintf, stderr;
     version (unittest) if (inUnittest) return false;
 
     fprintf(stderr, "%.*s %.*s option '%.*s'.\n",
@@ -191,6 +189,7 @@ bool parse(const(char)[] optname, ref inout(char)[] str, ref float res, const(ch
 in { assert(str.length); }
 do
 {
+  import core.stdc.stdio : snprintf, sscanf;
     // % uint f %n \0
     char[1 + 10 + 1 + 2 + 1] fmt=void;
     // specify max-width
@@ -242,6 +241,7 @@ do
 
 bool parseError(const scope char[] exp, const scope char[] opt, const scope char[] got, const(char)[] errName)
 {
+  import core.stdc.stdio : fprintf, stderr;
     version (unittest) if (inUnittest) return false;
 
     fprintf(stderr, "Expecting %.*s as argument for %.*s option '%.*s', got '%.*s' instead.\n",

--- a/src/core/internal/spinlock.d
+++ b/src/core/internal/spinlock.d
@@ -8,6 +8,33 @@
  */
 module core.internal.spinlock;
 
+version (WebAssembly) {
+  shared struct SpinLock {
+    /// for how long is the lock usually contended
+    enum Contention : ubyte
+      {
+        brief,
+          medium,
+          lengthy,
+          }
+    @trusted @nogc nothrow:
+    this(Contention contention) {}
+    void lock() {}
+    void unlock() {}
+    void yield(size_t k) {}
+  }
+  shared align(64)
+    struct AlignedSpinLock
+    {
+      this(SpinLock.Contention contention) @trusted @nogc nothrow
+      {
+      }
+      SpinLock impl;
+      alias impl this;
+    }
+
+} else:
+
 import core.atomic, core.thread;
 
 shared struct SpinLock

--- a/src/core/internal/utf.d
+++ b/src/core/internal/utf.d
@@ -293,6 +293,7 @@ dchar decode(const scope char[] s, ref size_t idx)
     return V; // dummy return
     }
 
+version (WebAssembly) {} else
 unittest
 {   size_t i;
     dchar c;

--- a/src/core/math.d
+++ b/src/core/math.d
@@ -1,4 +1,4 @@
-﻿// Written in the D programming language.
+// Written in the D programming language.
 
 /**
  * Builtin mathematical intrinsics
@@ -163,6 +163,11 @@ version (LDC)
                 }
             }
         }
+    } else version (WebAssembly) {
+      // TODO: linker doesn't like the ldexpl version, complaining about signature mismatch.
+      real ldexp(real n, int exp) @safe pure nothrow {
+        return cast(real)stdc.ldexp(cast(double)n, exp);
+      }
     }
     else // !MinGW
     {

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -1085,7 +1085,7 @@ else
 
     private @property void fakePureErrno()(int newValue) @nogc nothrow pure @system
     {
-        fakePureSetErrno(newValue);
+        cast(void)fakePureSetErrno(newValue);
     }
 }
 
@@ -1096,7 +1096,10 @@ extern (C) private @system @nogc nothrow
     ref int fakePureErrnoImpl()
     {
         import core.stdc.errno;
-        return errno();
+        version (WebAssembly)
+            return errno;
+        else
+            return errno();
     }
 }
 
@@ -1115,7 +1118,7 @@ extern(C) private @system nothrow @nogc
     pragma(mangle, "_d_delclass") void _d_delclass(Object*);
     pragma(mangle, "_d_delstruct") void _d_delstruct(void**, TypeInfo_Struct);
     pragma(mangle, "_d_delmemory") void _d_delmemory(void**);
-    pragma(mangle, "_d_delarray_t") void _d_delarray_t(void**, TypeInfo_Struct);
+    pragma(mangle, "_d_delarray_t") void _d_delarray_t(void[]*, TypeInfo_Struct);
 }
 
 /**

--- a/src/core/simd.d
+++ b/src/core/simd.d
@@ -12,6 +12,8 @@
 
 module core.simd;
 
+version (WebAssembly) {} else:
+
 pure:
 nothrow:
 @safe:

--- a/src/core/stdc/assert_.d
+++ b/src/core/stdc/assert_.d
@@ -22,6 +22,10 @@ extern (C):
 nothrow:
 @nogc:
 
+version (WebAssembly) {
+  version = WASI;
+}
+
 version (CRuntime_DigitalMars)
 {
     /***
@@ -105,6 +109,10 @@ else version (CRuntime_UClibc)
 else version (Solaris)
 {
     void __assert_c99(const(char)* exp, const(char)* file, uint line, const(char)* func);
+}
+else version (WASI)
+{
+    void __assert_fail(const(char)* exp, const(char)* file, uint line, const(char)* func);
 }
 else
 {

--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -13,6 +13,8 @@
 
 module core.stdc.config;
 
+version (WebAssembly) version = WASI_libc; // Always use the WASI libc for translating libc calls to wasi, see https://github.com/CraneStation/wasi-libc
+
 version (StdDdoc)
 {
     private
@@ -144,6 +146,37 @@ else version (Posix)
     alias ulong cpp_ulonglong;
   }
 }
+ else version (WASI_libc)
+   {
+     static if ( (void*).sizeof > int.sizeof )
+       {
+         enum __c_longlong  : long;
+         enum __c_ulonglong : ulong;
+
+         alias long  c_long;
+         alias ulong c_ulong;
+
+         alias long   cpp_long;
+         alias ulong  cpp_ulong;
+
+         alias __c_longlong  cpp_longlong;
+         alias __c_ulonglong cpp_ulonglong;
+       }
+     else
+       {
+         enum __c_long  : int;
+         enum __c_ulong : uint;
+
+         alias int   c_long;
+         alias uint  c_ulong;
+
+         alias __c_long   cpp_long;
+         alias __c_ulong  cpp_ulong;
+
+         alias long  cpp_longlong;
+         alias ulong cpp_ulonglong;
+       }
+   }
 
 version (CRuntime_Microsoft)
 {

--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -23,21 +23,22 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
-version (ARM)     version = ARM_Any;
-version (AArch64) version = ARM_Any;
-version (HPPA)    version = HPPA_Any;
-version (MIPS32)  version = MIPS_Any;
-version (MIPS64)  version = MIPS_Any;
-version (PPC)     version = PPC_Any;
-version (PPC64)   version = PPC_Any;
-version (RISCV32) version = RISCV_Any;
-version (RISCV64) version = RISCV_Any;
-version (S390)    version = IBMZ_Any;
-version (SPARC)   version = SPARC_Any;
-version (SPARC64) version = SPARC_Any;
-version (SystemZ) version = IBMZ_Any;
-version (X86)     version = X86_Any;
-version (X86_64)  version = X86_Any;
+version (ARM)         version = ARM_Any;
+version (AArch64)     version = ARM_Any;
+version (HPPA)        version = HPPA_Any;
+version (MIPS32)      version = MIPS_Any;
+version (MIPS64)      version = MIPS_Any;
+version (PPC)         version = PPC_Any;
+version (PPC64)       version = PPC_Any;
+version (RISCV32)     version = RISCV_Any;
+version (RISCV64)     version = RISCV_Any;
+version (S390)        version = IBMZ_Any;
+version (SPARC)       version = SPARC_Any;
+version (SPARC64)     version = SPARC_Any;
+version (SystemZ)     version = IBMZ_Any;
+version (X86)         version = X86_Any;
+version (X86_64)      version = X86_Any;
+version (WebAssembly) version = WASI_libc; // Always use the WASI libc for translating libc calls to wasi, see https://github.com/CraneStation/wasi-libc
 
 @trusted: // Only manipulates errno.
 nothrow:
@@ -153,6 +154,16 @@ else version (Haiku)
         alias errno = _errnop;
     }
 }
+ else version (WASI_libc) {
+   extern(C) {
+     __gshared extern int errno;
+   }
+   extern (C)
+   {
+     int getErrno() { return errno; };      // for internal use
+     int setErrno(int e) { errno = e; return 0; };   // for internal use
+   }
+ }
 else
 {
     ///
@@ -2036,6 +2047,142 @@ else version (Haiku)
     enum B_TRANSLATION_BASE_ERROR        = (B_TRANSLATION_ERROR_BASE + 0);
     enum B_NO_TRANSLATOR                 = (B_TRANSLATION_ERROR_BASE + 1);
     enum B_ILLEGAL_DATA                  = (B_TRANSLATION_ERROR_BASE + 2);
+}
+ else version(WASI_libc) {
+    enum EPERM            = 1;
+    enum ENOENT           = 2;
+    enum ESRCH            = 3;
+    enum EINTR            = 4;
+    enum EIO              = 5;
+    enum ENXIO            = 6;
+    enum E2BIG            = 7;
+    enum ENOEXEC          = 8;
+    enum EBADF            = 9;
+    enum ECHILD          = 10;
+    enum EAGAIN          = 11;
+    enum ENOMEM          = 12;
+    enum EACCES          = 13;
+    enum EFAULT          = 14;
+    enum ENOTBLK         = 15;
+    enum EBUSY           = 16;
+    enum EEXIST          = 17;
+    enum EXDEV           = 18;
+    enum ENODEV          = 19;
+    enum ENOTDIR         = 20;
+    enum EISDIR          = 21;
+    enum EINVAL          = 22;
+    enum ENFILE          = 23;
+    enum EMFILE          = 24;
+    enum ENOTTY          = 25;
+    enum ETXTBSY         = 26;
+    enum EFBIG           = 27;
+    enum ENOSPC          = 28;
+    enum ESPIPE          = 29;
+    enum EROFS           = 30;
+    enum EMLINK          = 31;
+    enum EPIPE           = 32;
+    enum EDOM            = 33;
+    enum ERANGE          = 34;
+    enum EDEADLK         = 35;
+    enum ENAMETOOLONG    = 36;
+    enum ENOLCK          = 37;
+    enum ENOSYS          = 38;
+    enum ENOTEMPTY       = 39;
+    enum ELOOP           = 40;
+    enum EWOULDBLOCK     = EAGAIN;
+    enum ENOMSG          = 42;
+    enum EIDRM           = 43;
+    enum ECHRNG          = 44;
+    enum EL2NSYNC        = 45;
+    enum EL3HLT          = 46;
+    enum EL3RST          = 47;
+    enum ELNRNG          = 48;
+    enum EUNATCH         = 49;
+    enum ENOCSI          = 50;
+    enum EL2HLT          = 51;
+    enum EBADE           = 52;
+    enum EBADR           = 53;
+    enum EXFULL          = 54;
+    enum ENOANO          = 55;
+    enum EBADRQC         = 56;
+    enum EBADSLT         = 57;
+    enum EDEADLOCK       = EDEADLK;
+    enum EBFONT          = 59;
+    enum ENOSTR          = 60;
+    enum ENODATA         = 61;
+    enum ETIME           = 62;
+    enum ENOSR           = 63;
+    enum ENONET          = 64;
+    enum ENOPKG          = 65;
+    enum EREMOTE         = 66;
+    enum ENOLINK         = 67;
+    enum EADV            = 68;
+    enum ESRMNT          = 69;
+    enum ECOMM           = 70;
+    enum EPROTO          = 71;
+    enum EMULTIHOP       = 72;
+    enum EDOTDOT         = 73;
+    enum EBADMSG         = 74;
+    enum EOVERFLOW       = 75;
+    enum ENOTUNIQ        = 76;
+    enum EBADFD          = 77;
+    enum EREMCHG         = 78;
+    enum ELIBACC         = 79;
+    enum ELIBBAD         = 80;
+    enum ELIBSCN         = 81;
+    enum ELIBMAX         = 82;
+    enum ELIBEXEC        = 83;
+    enum EILSEQ          = 84;
+    enum ERESTART        = 85;
+    enum ESTRPIPE        = 86;
+    enum EUSERS          = 87;
+    enum ENOTSOCK        = 88;
+    enum EDESTADDRREQ    = 89;
+    enum EMSGSIZE        = 90;
+    enum EPROTOTYPE      = 91;
+    enum ENOPROTOOPT     = 92;
+    enum EPROTONOSUPPORT = 93;
+    enum ESOCKTNOSUPPORT = 94;
+    enum EOPNOTSUPP      = 95;
+    enum ENOTSUP         = EOPNOTSUPP;
+    enum EPFNOSUPPORT    = 96;
+    enum EAFNOSUPPORT    = 97;
+    enum EADDRINUSE      = 98;
+    enum EADDRNOTAVAIL   = 99;
+    enum ENETDOWN        = 100;
+    enum ENETUNREACH     = 101;
+    enum ENETRESET       = 102;
+    enum ECONNABORTED    = 103;
+    enum ECONNRESET      = 104;
+    enum ENOBUFS         = 105;
+    enum EISCONN         = 106;
+    enum ENOTCONN        = 107;
+    enum ESHUTDOWN       = 108;
+    enum ETOOMANYREFS    = 109;
+    enum ETIMEDOUT       = 110;
+    enum ECONNREFUSED    = 111;
+    enum EHOSTDOWN       = 112;
+    enum EHOSTUNREACH    = 113;
+    enum EALREADY        = 114;
+    enum EINPROGRESS     = 115;
+    enum ESTALE          = 116;
+    enum EUCLEAN         = 117;
+    enum ENOTNAM         = 118;
+    enum ENAVAIL         = 119;
+    enum EISNAM          = 120;
+    enum EREMOTEIO       = 121;
+    enum EDQUOT          = 122;
+    enum ENOMEDIUM       = 123;
+    enum EMEDIUMTYPE     = 124;
+    enum ECANCELED       = 125;
+    enum ENOKEY          = 126;
+    enum EKEYEXPIRED     = 127;
+    enum EKEYREVOKED     = 128;
+    enum EKEYREJECTED    = 129;
+    enum EOWNERDEAD      = 130;
+    enum ENOTRECOVERABLE = 131;
+    enum ERFKILL         = 132;
+    enum EHWPOISON       = 133;
 }
 else
 {

--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -156,12 +156,12 @@ else version (Haiku)
 }
  else version (WASI_libc) {
    extern(C) {
-     __gshared extern int errno;
+       extern int errno;
    }
    extern (C)
    {
-     int getErrno() { return errno; };      // for internal use
-     int setErrno(int e) { errno = e; return 0; };   // for internal use
+       extern int getErrno();// { return errno; };      // for internal use
+       extern int setErrno(int e);// { errno = e; return 0; };   // for internal use
    }
  }
 else

--- a/src/core/stdc/locale.d
+++ b/src/core/stdc/locale.d
@@ -22,6 +22,8 @@ else version (TVOS)
     version = Darwin;
 else version (WatchOS)
     version = Darwin;
+else version (WebAssembly)
+  version = WASI;
 
 extern (C):
 @trusted: // Only setlocale operates on C strings.
@@ -280,6 +282,23 @@ else version (CRuntime_UClibc)
     enum LC_MEASUREMENT    = 11;
     ///
     enum LC_IDENTIFICATION = 12;
+}
+else version (WASI)
+{
+    ///
+    enum LC_CTYPE          = 0;
+    ///
+    enum LC_NUMERIC        = 1;
+    ///
+    enum LC_TIME           = 2;
+    ///
+    enum LC_COLLATE        = 3;
+    ///
+    enum LC_MONETARY       = 4;
+    ///
+    enum LC_MESSAGES       = 5;
+    ///
+    enum LC_ALL            = 6;
 }
 else
 {

--- a/src/core/stdc/stddef.d
+++ b/src/core/stdc/stddef.d
@@ -34,3 +34,8 @@ else version (Posix)
     ///
     alias dchar wchar_t;
 }
+else version (WebAssembly)
+{
+    ///
+    alias dchar wchar_t;
+}

--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -19,6 +19,7 @@ private import core.stdc.stddef; // for wchar_t
 private import core.stdc.signal; // for sig_atomic_t
 private import core.stdc.wchar_; // for wint_t
 
+version (WebAssembly) version = WASI_libc; // Always use the WASI libc for translating libc calls to wasi, see https://github.com/CraneStation/wasi-libc
 
 // Can't be `private` because of @@@BUG11173@@@.
 T _typify(T)(T val) @safe pure nothrow { return val; }
@@ -158,6 +159,41 @@ else version (Posix)
         alias int_fast32_t  = ptrdiff_t; ///
         alias uint_fast32_t = size_t;    ///
     }
+    alias int_fast64_t  = long;      ///
+    alias uint_fast64_t = ulong;     ///
+
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
+}
+ else version (WASI_libc)
+{
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
+
+    alias int_least8_t   = byte;   ///
+    alias uint_least8_t  = ubyte;  ///
+    alias int_least16_t  = short;  ///
+    alias uint_least16_t = ushort; ///
+    alias int_least32_t  = int;    ///
+    alias uint_least32_t = uint;   ///
+    alias int_least64_t  = long;   ///
+    alias uint_least64_t = ulong;  ///
+
+    alias int_fast8_t   = byte;      ///
+    alias uint_fast8_t  = ubyte;     ///
+    alias int_fast16_t  = ptrdiff_t; ///
+    alias uint_fast16_t = size_t;    ///
+    alias int_fast32_t  = ptrdiff_t; ///
+    alias uint_fast32_t = size_t;    ///
+
     alias int_fast64_t  = long;      ///
     alias uint_fast64_t = ulong;     ///
 

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -95,6 +95,7 @@ else version (Solaris) enum RAND_MAX = 0x7fff;
 else version (CRuntime_Bionic) enum RAND_MAX = 0x7fffffff;
 else version (CRuntime_Musl) enum RAND_MAX = 0x7fffffff;
 else version (CRuntime_UClibc) enum RAND_MAX = 0x7fffffff;
+else version (WebAssembly) enum RAND_MAX = 0x7fffffff;
 else static assert( false, "Unsupported platform" );
 
 ///

--- a/src/core/stdc/tgmath.d
+++ b/src/core/stdc/tgmath.d
@@ -14,6 +14,8 @@
 
 module core.stdc.tgmath;
 
+version (WebAssembly) {} else:
+
 private import core.stdc.config;
 private static import core.stdc.math;
 private static import core.stdc.complex;

--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -26,6 +26,8 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
+version (WebAssembly) version = WASI_libc; // Always use the WASI libc for translating libc calls to wasi, see https://github.com/CraneStation/wasi-libc
+
 extern (C):
 @trusted: // There are only a few functions here that use unsafe C strings.
 nothrow:
@@ -65,8 +67,30 @@ else version (Posix)
         char*   tm_zone;    /// timezone abbreviation
     }
 }
+ else version (WASI_libc)
+{
+    ///
+    struct tm
+    {
+        int     tm_sec;     /// seconds after the minute [0-60]
+        int     tm_min;     /// minutes after the hour [0-59]
+        int     tm_hour;    /// hours since midnight [0-23]
+        int     tm_mday;    /// day of the month [1-31]
+        int     tm_mon;     /// months since January [0-11]
+        int     tm_year;    /// years since 1900
+        int     tm_wday;    /// days since Sunday [0-6]
+        int     tm_yday;    /// days since January 1 [0-365]
+        int     tm_isdst;   /// Daylight Savings Time flag
+        c_long  tm_gmtoff;  /// offset from CUT in seconds
+        char*   tm_zone;    /// timezone abbreviation
+    }
+}
 
-version (Posix)
+version (WASI_libc)
+{
+    public import core.sys.wasi.sys.types : time_t, clock_t;
+}
+else version (Posix)
 {
     public import core.sys.posix.sys.types : time_t, clock_t;
 }
@@ -138,6 +162,11 @@ else version (CRuntime_Bionic)
     clock_t clock();
 }
 else version (CRuntime_UClibc)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+ else version (WASI_libc)
 {
     enum clock_t CLOCKS_PER_SEC = 1_000_000;
     clock_t clock();
@@ -248,6 +277,12 @@ else version (CRuntime_UClibc)
     void tzset();
     ///
     extern __gshared const(char)*[2] tzname;
+}
+ else version (WASI_libc)
+{
+    ///
+  // TODO: wasm has no tzset nor tzname, find better workaround
+  void tzset() {};
 }
 else
 {

--- a/src/core/sync/barrier.d
+++ b/src/core/sync/barrier.d
@@ -15,6 +15,7 @@
  */
 module core.sync.barrier;
 
+version (WebAssembly) {} else:
 
 public import core.sync.exception;
 private import core.sync.condition;

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -15,6 +15,7 @@
  */
 module core.sync.condition;
 
+version (WebAssembly) {} else:
 
 public import core.sync.exception;
 public import core.sync.mutex;

--- a/src/core/sync/event.d
+++ b/src/core/sync/event.d
@@ -11,6 +11,8 @@
  */
 module core.sync.event;
 
+version (WebAssembly) {} else:
+
 version (Windows)
 {
     import core.sys.windows.basetsd /+: HANDLE +/;

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -15,7 +15,6 @@
  */
 module core.sync.mutex;
 
-
 public import core.sync.exception;
 
 version (Windows)
@@ -27,6 +26,173 @@ version (Windows)
 else version (Posix)
 {
     private import core.sys.posix.pthread;
+}
+else version (WebAssembly)
+{
+class Mutex :
+    Object.Monitor
+{
+    ////////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ////////////////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Initializes a mutex object.
+     *
+     */
+    this() @trusted nothrow @nogc
+    {
+        this(true);
+    }
+
+    /// ditto
+    this() shared @trusted nothrow @nogc
+    {
+        this(true);
+    }
+
+    // Undocumented, useful only in Mutex.this().
+    private this(this Q)(bool _unused_) @trusted nothrow @nogc
+        if (is(Q == Mutex) || is(Q == shared Mutex))
+    {
+        m_proxy.link = this;
+        this.__monitor = cast(void*) &m_proxy;
+    }
+
+
+    /**
+     * Initializes a mutex object and sets it as the monitor for `obj`.
+     *
+     * In:
+     *  `obj` must not already have a monitor.
+     */
+    this(Object obj) @trusted nothrow @nogc
+    {
+        this(obj, true);
+    }
+
+    /// ditto
+    this(Object obj) shared @trusted nothrow @nogc
+    {
+        this(obj, true);
+    }
+
+    // Undocumented, useful only in Mutex.this(Object).
+    private this(this Q)(Object obj, bool _unused_) @trusted nothrow @nogc
+        if (is(Q == Mutex) || is(Q == shared Mutex))
+    in
+    {
+        assert(obj !is null,
+            "The provided object must not be null.");
+        assert(obj.__monitor is null,
+            "The provided object has a monitor already set!");
+    }
+    do
+    {
+        this();
+        obj.__monitor = cast(void*) &m_proxy;
+    }
+
+
+    ~this() @trusted nothrow @nogc
+    {
+        this.__monitor = null;
+    }
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    // General Actions
+    ////////////////////////////////////////////////////////////////////////////
+
+
+    /**
+     * If this lock is not already held by the caller, the lock is acquired,
+     * then the internal counter is incremented by one.
+     *
+     * Note:
+     *    `Mutex.lock` does not throw, but a class derived from Mutex can throw.
+     *    Use `lock_nothrow` in `nothrow @nogc` code.
+     */
+    @trusted void lock()
+    {
+    }
+
+    /// ditto
+    @trusted void lock() shared
+    {
+    }
+
+    /// ditto
+    final void lock_nothrow(this Q)() nothrow @trusted @nogc
+        if (is(Q == Mutex) || is(Q == shared Mutex))
+    {
+    }
+
+    /**
+     * Decrements the internal lock count by one.  If this brings the count to
+     * zero, the lock is released.
+     *
+     * Note:
+     *    `Mutex.unlock` does not throw, but a class derived from Mutex can throw.
+     *    Use `unlock_nothrow` in `nothrow @nogc` code.
+     */
+    @trusted void unlock()
+    {
+    }
+
+    /// ditto
+    @trusted void unlock() shared
+    {
+    }
+
+    /// ditto
+    final void unlock_nothrow(this Q)() nothrow @trusted @nogc
+        if (is(Q == Mutex) || is(Q == shared Mutex))
+    {
+    }
+
+    /**
+     * If the lock is held by another caller, the method returns.  Otherwise,
+     * the lock is acquired if it is not already held, and then the internal
+     * counter is incremented by one.
+     *
+     * Returns:
+     *  true if the lock was acquired and false if not.
+     *
+     * Note:
+     *    `Mutex.tryLock` does not throw, but a class derived from Mutex can throw.
+     *    Use `tryLock_nothrow` in `nothrow @nogc` code.
+     */
+    bool tryLock() @trusted
+    {
+        return tryLock_nothrow();
+    }
+
+    /// ditto
+    bool tryLock() shared @trusted
+    {
+        return tryLock_nothrow();
+    }
+
+    /// ditto
+    final bool tryLock_nothrow(this Q)() nothrow @trusted @nogc
+        if (is(Q == Mutex) || is(Q == shared Mutex))
+    {
+      return true;
+    }
+
+
+private:
+    struct MonitorProxy
+    {
+        Object.Monitor link;
+    }
+
+    MonitorProxy            m_proxy;
+
+
+}
 }
 else
 {
@@ -42,6 +208,7 @@ else
 ////////////////////////////////////////////////////////////////////////////////
 
 
+version (WebAssembly) {} else
 /**
  * This class represents a general purpose, recursive mutex.
  *
@@ -302,6 +469,7 @@ package:
 ///
 /* @safe nothrow -> see druntime PR 1726 */
 // Test regular usage.
+version (WebAssembly) {} else // TODO: no threads yet
 unittest
 {
     import core.thread : Thread;
@@ -399,6 +567,7 @@ unittest
     m.unlock();
 }
 
+version (WebAssembly) {} else // TODO: no threads yet
 unittest
 {
     import core.thread;

--- a/src/core/sync/rwmutex.d
+++ b/src/core/sync/rwmutex.d
@@ -15,6 +15,7 @@
  */
 module core.sync.rwmutex;
 
+version (WebAssembly) {} else:
 
 public import core.sync.exception;
 private import core.sync.condition;

--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -14,6 +14,7 @@
  */
 module core.sync.semaphore;
 
+version (WebAssembly) {} else:
 
 public import core.sync.exception;
 public import core.time;

--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -442,6 +442,43 @@ else version (linux)
         INADDR_NONE      = 0xFFFFFFFF
     }
 }
+else version (WebAssembly) // TODO: needs to be WASI
+{
+  static assert("No wasm in posix...");
+    private enum __SOCK_SIZE__ = 16;
+
+    struct sockaddr_in
+    {
+        sa_family_t sin_family;
+        ushort      sin_port;
+        in_addr     sin_addr;
+
+        /* Pad to size of `struct sockaddr'. */
+        ubyte[__SOCK_SIZE__ - sa_family_t.sizeof -
+              ushort.sizeof - in_addr.sizeof] __pad;
+    }
+
+    enum
+    {
+        IPPROTO_IP   = 0,
+        IPPROTO_ICMP = 1,
+        IPPROTO_IGMP = 2,
+        IPPROTO_GGP  = 3,
+        IPPROTO_TCP  = 6,
+        IPPROTO_PUP  = 12,
+        IPPROTO_UDP  = 17,
+        IPPROTO_IDP  = 22,
+	IPPROTO_RAW  = 255
+    }
+
+    enum : c_ulong
+    {
+        INADDR_ANY       = 0x00000000,
+        INADDR_BROADCAST = 0xffffffff,
+        INADDR_LOOPBACK  = 0x7f000001,
+        INADDR_NONE      = 0xFFFFFFFF
+    }
+}
 
 
 //

--- a/src/core/sys/posix/netinet/tcp.d
+++ b/src/core/sys/posix/netinet/tcp.d
@@ -67,3 +67,8 @@ else version (linux)
 {
     enum TCP_NODELAY = 1;
 }
+else version (WebAssembly) // TODO: needs to be WASI
+{
+  static assert("No wasm in posix...");
+    enum TCP_NODELAY = 1;
+}

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -1822,6 +1822,23 @@ else version (CRuntime_UClibc)
     else
         static assert(0, "unimplemented");
 }
+else version (WebAssembly) // TODO: needs to be WASI
+{
+  static assert("No wasm in posix...");
+	struct mcontext_t
+	{
+		ulong[32] __space;
+	}
+	struct ucontext_t
+	{
+		ulong uc_flags;
+		ucontext_t *uc_link;
+		stack_t uc_stack;
+		mcontext_t uc_mcontext;
+		sigset_t uc_sigmask;
+		ulong[64] __fpregs_mem;
+	}
+}
 
 //
 // Obsolescent (OB)
@@ -1860,4 +1877,3 @@ version (Solaris)
     int addrtosymstr(uintptr_t, char*, int);
     int printstack(int);
 }
-

--- a/src/core/sys/wasi/config.d
+++ b/src/core/sys/wasi/config.d
@@ -1,0 +1,38 @@
+/**
+ * D header file for WASI.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Sean Kelly,
+ Alex Rønne Petersen
+ * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ */
+
+/*          Copyright Sean Kelly 2005 - 2009.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.sys.wasi.config;
+
+public import core.stdc.config;
+
+version (WebAssembly)
+    version = WASI;
+
+version (WASI):
+extern (C) nothrow @nogc:
+
+enum _XOPEN_SOURCE     = 600;
+enum _POSIX_SOURCE     = true;
+enum _POSIX_C_SOURCE   = 200112L;
+
+enum _FILE_OFFSET_BITS   = 64;
+
+enum __REDIRECT          = false;
+
+enum __USE_FILE_OFFSET64 = _FILE_OFFSET_BITS == 64;
+enum __USE_LARGEFILE     = __USE_FILE_OFFSET64 && !__REDIRECT;
+enum __USE_LARGEFILE64   = __USE_FILE_OFFSET64 && !__REDIRECT;
+
+enum __WORDSIZE=64;

--- a/src/core/sys/wasi/core.d
+++ b/src/core/sys/wasi/core.d
@@ -1,0 +1,591 @@
+/*
+ * This file describes the WASI interface, consisting of functions, types,
+ * and defined values (macros).
+ *
+ * The interface described here is greatly inspired by [CloudABI]'s clean,
+ * thoughtfully-designed, cabability-oriented, POSIX-style API.
+ *
+ * [CloudABI]: https://github.com/NuxiNL/cloudlibc
+ */
+
+module core.sys.wasi.core;
+
+version (WebAssembly) {
+  version = WASI;
+}
+
+version (WASI):
+
+@safe:
+nothrow:
+@nogc:
+
+import core.stdc.stdint;
+
+extern (C):
+
+alias __wasi_advice_t = ubyte;
+enum __WASI_ADVICE_NORMAL = UINT8_C(0);
+enum __WASI_ADVICE_SEQUENTIAL = UINT8_C(1);
+enum __WASI_ADVICE_RANDOM = UINT8_C(2);
+enum __WASI_ADVICE_WILLNEED = UINT8_C(3);
+enum __WASI_ADVICE_DONTNEED = UINT8_C(4);
+enum __WASI_ADVICE_NOREUSE = UINT8_C(5);
+
+alias __wasi_clockid_t = uint;
+enum __WASI_CLOCK_REALTIME = UINT32_C(0);
+enum __WASI_CLOCK_MONOTONIC = UINT32_C(1);
+enum __WASI_CLOCK_PROCESS_CPUTIME_ID = UINT32_C(2);
+enum __WASI_CLOCK_THREAD_CPUTIME_ID = UINT32_C(3);
+
+alias __wasi_device_t = ulong;
+
+alias __wasi_dircookie_t = ulong;
+enum __WASI_DIRCOOKIE_START = UINT64_C(0);
+
+alias __wasi_errno_t = ushort;
+enum __WASI_ESUCCESS = UINT16_C(0);
+enum __WASI_E2BIG = UINT16_C(1);
+enum __WASI_EACCES = UINT16_C(2);
+enum __WASI_EADDRINUSE = UINT16_C(3);
+enum __WASI_EADDRNOTAVAIL = UINT16_C(4);
+enum __WASI_EAFNOSUPPORT = UINT16_C(5);
+enum __WASI_EAGAIN = UINT16_C(6);
+enum __WASI_EALREADY = UINT16_C(7);
+enum __WASI_EBADF = UINT16_C(8);
+enum __WASI_EBADMSG = UINT16_C(9);
+enum __WASI_EBUSY = UINT16_C(10);
+enum __WASI_ECANCELED = UINT16_C(11);
+enum __WASI_ECHILD = UINT16_C(12);
+enum __WASI_ECONNABORTED = UINT16_C(13);
+enum __WASI_ECONNREFUSED = UINT16_C(14);
+enum __WASI_ECONNRESET = UINT16_C(15);
+enum __WASI_EDEADLK = UINT16_C(16);
+enum __WASI_EDESTADDRREQ = UINT16_C(17);
+enum __WASI_EDOM = UINT16_C(18);
+enum __WASI_EDQUOT = UINT16_C(19);
+enum __WASI_EEXIST = UINT16_C(20);
+enum __WASI_EFAULT = UINT16_C(21);
+enum __WASI_EFBIG = UINT16_C(22);
+enum __WASI_EHOSTUNREACH = UINT16_C(23);
+enum __WASI_EIDRM = UINT16_C(24);
+enum __WASI_EILSEQ = UINT16_C(25);
+enum __WASI_EINPROGRESS = UINT16_C(26);
+enum __WASI_EINTR = UINT16_C(27);
+enum __WASI_EINVAL = UINT16_C(28);
+enum __WASI_EIO = UINT16_C(29);
+enum __WASI_EISCONN = UINT16_C(30);
+enum __WASI_EISDIR = UINT16_C(31);
+enum __WASI_ELOOP = UINT16_C(32);
+enum __WASI_EMFILE = UINT16_C(33);
+enum __WASI_EMLINK = UINT16_C(34);
+enum __WASI_EMSGSIZE = UINT16_C(35);
+enum __WASI_EMULTIHOP = UINT16_C(36);
+enum __WASI_ENAMETOOLONG = UINT16_C(37);
+enum __WASI_ENETDOWN = UINT16_C(38);
+enum __WASI_ENETRESET = UINT16_C(39);
+enum __WASI_ENETUNREACH = UINT16_C(40);
+enum __WASI_ENFILE = UINT16_C(41);
+enum __WASI_ENOBUFS = UINT16_C(42);
+enum __WASI_ENODEV = UINT16_C(43);
+enum __WASI_ENOENT = UINT16_C(44);
+enum __WASI_ENOEXEC = UINT16_C(45);
+enum __WASI_ENOLCK = UINT16_C(46);
+enum __WASI_ENOLINK = UINT16_C(47);
+enum __WASI_ENOMEM = UINT16_C(48);
+enum __WASI_ENOMSG = UINT16_C(49);
+enum __WASI_ENOPROTOOPT = UINT16_C(50);
+enum __WASI_ENOSPC = UINT16_C(51);
+enum __WASI_ENOSYS = UINT16_C(52);
+enum __WASI_ENOTCONN = UINT16_C(53);
+enum __WASI_ENOTDIR = UINT16_C(54);
+enum __WASI_ENOTEMPTY = UINT16_C(55);
+enum __WASI_ENOTRECOVERABLE = UINT16_C(56);
+enum __WASI_ENOTSOCK = UINT16_C(57);
+enum __WASI_ENOTSUP = UINT16_C(58);
+enum __WASI_ENOTTY = UINT16_C(59);
+enum __WASI_ENXIO = UINT16_C(60);
+enum __WASI_EOVERFLOW = UINT16_C(61);
+enum __WASI_EOWNERDEAD = UINT16_C(62);
+enum __WASI_EPERM = UINT16_C(63);
+enum __WASI_EPIPE = UINT16_C(64);
+enum __WASI_EPROTO = UINT16_C(65);
+enum __WASI_EPROTONOSUPPORT = UINT16_C(66);
+enum __WASI_EPROTOTYPE = UINT16_C(67);
+enum __WASI_ERANGE = UINT16_C(68);
+enum __WASI_EROFS = UINT16_C(69);
+enum __WASI_ESPIPE = UINT16_C(70);
+enum __WASI_ESRCH = UINT16_C(71);
+enum __WASI_ESTALE = UINT16_C(72);
+enum __WASI_ETIMEDOUT = UINT16_C(73);
+enum __WASI_ETXTBSY = UINT16_C(74);
+enum __WASI_EXDEV = UINT16_C(75);
+enum __WASI_ENOTCAPABLE = UINT16_C(76);
+
+alias __wasi_eventrwflags_t = ushort;
+enum __WASI_EVENT_FD_READWRITE_HANGUP = UINT16_C(0x0001);
+
+alias __wasi_eventtype_t = ubyte;
+enum __WASI_EVENTTYPE_CLOCK = UINT8_C(0);
+enum __WASI_EVENTTYPE_FD_READ = UINT8_C(1);
+enum __WASI_EVENTTYPE_FD_WRITE = UINT8_C(2);
+
+alias __wasi_exitcode_t = uint;
+
+alias __wasi_fd_t = uint;
+
+alias __wasi_fdflags_t = ushort;
+enum __WASI_FDFLAG_APPEND = UINT16_C(0x0001);
+enum __WASI_FDFLAG_DSYNC = UINT16_C(0x0002);
+enum __WASI_FDFLAG_NONBLOCK = UINT16_C(0x0004);
+enum __WASI_FDFLAG_RSYNC = UINT16_C(0x0008);
+enum __WASI_FDFLAG_SYNC = UINT16_C(0x0010);
+
+alias __wasi_filedelta_t = long;
+
+alias __wasi_filesize_t = ulong;
+
+alias __wasi_filetype_t = ubyte;
+enum __WASI_FILETYPE_UNKNOWN = UINT8_C(0);
+enum __WASI_FILETYPE_BLOCK_DEVICE = UINT8_C(1);
+enum __WASI_FILETYPE_CHARACTER_DEVICE = UINT8_C(2);
+enum __WASI_FILETYPE_DIRECTORY = UINT8_C(3);
+enum __WASI_FILETYPE_REGULAR_FILE = UINT8_C(4);
+enum __WASI_FILETYPE_SOCKET_DGRAM = UINT8_C(5);
+enum __WASI_FILETYPE_SOCKET_STREAM = UINT8_C(6);
+enum __WASI_FILETYPE_SYMBOLIC_LINK = UINT8_C(7);
+
+alias __wasi_fstflags_t = ushort;
+enum __WASI_FILESTAT_SET_ATIM = UINT16_C(0x0001);
+enum __WASI_FILESTAT_SET_ATIM_NOW = UINT16_C(0x0002);
+enum __WASI_FILESTAT_SET_MTIM = UINT16_C(0x0004);
+enum __WASI_FILESTAT_SET_MTIM_NOW = UINT16_C(0x0008);
+
+alias __wasi_inode_t = ulong;
+
+alias __wasi_linkcount_t = uint;
+
+alias __wasi_lookupflags_t = uint;
+enum __WASI_LOOKUP_SYMLINK_FOLLOW = UINT32_C(0x00000001);
+
+alias __wasi_oflags_t = ushort;
+enum __WASI_O_CREAT = UINT16_C(0x0001);
+enum __WASI_O_DIRECTORY = UINT16_C(0x0002);
+enum __WASI_O_EXCL = UINT16_C(0x0004);
+enum __WASI_O_TRUNC = UINT16_C(0x0008);
+
+alias __wasi_riflags_t = ushort;
+enum __WASI_SOCK_RECV_PEEK = UINT16_C(0x0001);
+enum __WASI_SOCK_RECV_WAITALL = UINT16_C(0x0002);
+
+alias __wasi_rights_t = ulong;
+enum __WASI_RIGHT_FD_DATASYNC = UINT64_C(0x0000000000000001);
+enum __WASI_RIGHT_FD_READ = UINT64_C(0x0000000000000002);
+enum __WASI_RIGHT_FD_SEEK = UINT64_C(0x0000000000000004);
+enum __WASI_RIGHT_FD_FDSTAT_SET_FLAGS = UINT64_C(0x0000000000000008);
+enum __WASI_RIGHT_FD_SYNC = UINT64_C(0x0000000000000010);
+enum __WASI_RIGHT_FD_TELL = UINT64_C(0x0000000000000020);
+enum __WASI_RIGHT_FD_WRITE = UINT64_C(0x0000000000000040);
+enum __WASI_RIGHT_FD_ADVISE = UINT64_C(0x0000000000000080);
+enum __WASI_RIGHT_FD_ALLOCATE = UINT64_C(0x0000000000000100);
+enum __WASI_RIGHT_PATH_CREATE_DIRECTORY = UINT64_C(0x0000000000000200);
+enum __WASI_RIGHT_PATH_CREATE_FILE = UINT64_C(0x0000000000000400);
+enum __WASI_RIGHT_PATH_LINK_SOURCE = UINT64_C(0x0000000000000800);
+enum __WASI_RIGHT_PATH_LINK_TARGET = UINT64_C(0x0000000000001000);
+enum __WASI_RIGHT_PATH_OPEN = UINT64_C(0x0000000000002000);
+enum __WASI_RIGHT_FD_READDIR = UINT64_C(0x0000000000004000);
+enum __WASI_RIGHT_PATH_READLINK = UINT64_C(0x0000000000008000);
+enum __WASI_RIGHT_PATH_RENAME_SOURCE = UINT64_C(0x0000000000010000);
+enum __WASI_RIGHT_PATH_RENAME_TARGET = UINT64_C(0x0000000000020000);
+enum __WASI_RIGHT_PATH_FILESTAT_GET = UINT64_C(0x0000000000040000);
+enum __WASI_RIGHT_PATH_FILESTAT_SET_SIZE = UINT64_C(0x0000000000080000);
+enum __WASI_RIGHT_PATH_FILESTAT_SET_TIMES = UINT64_C(0x0000000000100000);
+enum __WASI_RIGHT_FD_FILESTAT_GET = UINT64_C(0x0000000000200000);
+enum __WASI_RIGHT_FD_FILESTAT_SET_SIZE = UINT64_C(0x0000000000400000);
+enum __WASI_RIGHT_FD_FILESTAT_SET_TIMES = UINT64_C(0x0000000000800000);
+enum __WASI_RIGHT_PATH_SYMLINK = UINT64_C(0x0000000001000000);
+enum __WASI_RIGHT_PATH_REMOVE_DIRECTORY = UINT64_C(0x0000000002000000);
+enum __WASI_RIGHT_PATH_UNLINK_FILE = UINT64_C(0x0000000004000000);
+enum __WASI_RIGHT_POLL_FD_READWRITE = UINT64_C(0x0000000008000000);
+enum __WASI_RIGHT_SOCK_SHUTDOWN = UINT64_C(0x0000000010000000);
+
+alias __wasi_roflags_t = ushort;
+enum __WASI_SOCK_RECV_DATA_TRUNCATED = UINT16_C(0x0001);
+
+alias __wasi_sdflags_t = ubyte;
+enum __WASI_SHUT_RD = UINT8_C(0x01);
+enum __WASI_SHUT_WR = UINT8_C(0x02);
+
+alias __wasi_siflags_t = ushort;
+
+alias __wasi_signal_t = ubyte;
+/* UINT8_C(0) is reserved; POSIX has special semantics for kill(pid, 0). */
+enum __WASI_SIGHUP = UINT8_C(1);
+enum __WASI_SIGINT = UINT8_C(2);
+enum __WASI_SIGQUIT = UINT8_C(3);
+enum __WASI_SIGILL = UINT8_C(4);
+enum __WASI_SIGTRAP = UINT8_C(5);
+enum __WASI_SIGABRT = UINT8_C(6);
+enum __WASI_SIGBUS = UINT8_C(7);
+enum __WASI_SIGFPE = UINT8_C(8);
+enum __WASI_SIGKILL = UINT8_C(9);
+enum __WASI_SIGUSR1 = UINT8_C(10);
+enum __WASI_SIGSEGV = UINT8_C(11);
+enum __WASI_SIGUSR2 = UINT8_C(12);
+enum __WASI_SIGPIPE = UINT8_C(13);
+enum __WASI_SIGALRM = UINT8_C(14);
+enum __WASI_SIGTERM = UINT8_C(15);
+enum __WASI_SIGCHLD = UINT8_C(16);
+enum __WASI_SIGCONT = UINT8_C(17);
+enum __WASI_SIGSTOP = UINT8_C(18);
+enum __WASI_SIGTSTP = UINT8_C(19);
+enum __WASI_SIGTTIN = UINT8_C(20);
+enum __WASI_SIGTTOU = UINT8_C(21);
+enum __WASI_SIGURG = UINT8_C(22);
+enum __WASI_SIGXCPU = UINT8_C(23);
+enum __WASI_SIGXFSZ = UINT8_C(24);
+enum __WASI_SIGVTALRM = UINT8_C(25);
+enum __WASI_SIGPROF = UINT8_C(26);
+enum __WASI_SIGWINCH = UINT8_C(27);
+enum __WASI_SIGPOLL = UINT8_C(28);
+enum __WASI_SIGPWR = UINT8_C(29);
+enum __WASI_SIGSYS = UINT8_C(30);
+
+alias __wasi_subclockflags_t = ushort;
+enum __WASI_SUBSCRIPTION_CLOCK_ABSTIME = UINT16_C(0x0001);
+
+alias __wasi_timestamp_t = ulong;
+
+alias __wasi_userdata_t = ulong;
+
+alias __wasi_whence_t = ubyte;
+enum __WASI_WHENCE_CUR = UINT8_C(0);
+enum __WASI_WHENCE_END = UINT8_C(1);
+enum __WASI_WHENCE_SET = UINT8_C(2);
+
+alias __wasi_preopentype_t = ubyte;
+enum __WASI_PREOPENTYPE_DIR = UINT8_C(0);
+
+struct __wasi_dirent_t
+{
+  __wasi_dircookie_t d_next;
+  __wasi_inode_t d_ino;
+  uint d_namlen;
+  __wasi_filetype_t d_type;
+}
+
+struct __wasi_event_t
+{
+  __wasi_userdata_t userdata;
+  __wasi_errno_t error;
+  __wasi_eventtype_t type;
+
+  union __wasi_event_u
+  {
+    struct __wasi_event_u_fd_readwrite_t
+    {
+      __wasi_filesize_t nbytes;
+      __wasi_eventrwflags_t flags;
+    }
+
+    __wasi_event_u_fd_readwrite_t fd_readwrite;
+  }
+
+  __wasi_event_u u;
+}
+
+struct __wasi_prestat_t
+{
+  __wasi_preopentype_t pr_type;
+
+  union __wasi_prestat_u
+  {
+    struct __wasi_prestat_u_dir_t
+    {
+      size_t pr_name_len;
+    }
+
+    __wasi_prestat_u_dir_t dir;
+  }
+
+  __wasi_prestat_u u;
+}
+
+struct __wasi_fdstat_t
+{
+  __wasi_filetype_t fs_filetype;
+  __wasi_fdflags_t fs_flags;
+  __wasi_rights_t fs_rights_base;
+  __wasi_rights_t fs_rights_inheriting;
+}
+
+struct __wasi_filestat_t
+{
+  __wasi_device_t st_dev;
+  __wasi_inode_t st_ino;
+  __wasi_filetype_t st_filetype;
+  __wasi_linkcount_t st_nlink;
+  __wasi_filesize_t st_size;
+  __wasi_timestamp_t st_atim;
+  __wasi_timestamp_t st_mtim;
+  __wasi_timestamp_t st_ctim;
+}
+
+struct __wasi_ciovec_t
+{
+  const(void)* buf;
+  size_t buf_len;
+}
+
+struct __wasi_iovec_t
+{
+  void* buf;
+  size_t buf_len;
+}
+
+struct __wasi_subscription_t
+{
+  __wasi_userdata_t userdata;
+  __wasi_eventtype_t type;
+
+  union __wasi_subscription_u
+  {
+    struct __wasi_subscription_u_clock_t
+    {
+      __wasi_userdata_t identifier;
+      __wasi_clockid_t clock_id;
+      __wasi_timestamp_t timeout;
+      __wasi_timestamp_t precision;
+      __wasi_subclockflags_t flags;
+    }
+
+    __wasi_subscription_u_clock_t clock;
+
+    struct __wasi_subscription_u_fd_readwrite_t
+    {
+      __wasi_fd_t fd;
+    }
+
+    __wasi_subscription_u_fd_readwrite_t fd_readwrite;
+  }
+
+  __wasi_subscription_u u;
+}
+
+import ldc.attributes;
+@llvmAttr("wasm-import-module", "wasi_unstable") {
+
+  __wasi_errno_t args_get (char** argv, char* argv_buf);
+
+  __wasi_errno_t args_sizes_get (size_t* argc, size_t* argv_buf_size);
+
+  __wasi_errno_t clock_res_get (
+                                __wasi_clockid_t clock_id,
+                                __wasi_timestamp_t* resolution);
+
+  __wasi_errno_t clock_time_get (
+                                 __wasi_clockid_t clock_id,
+                                 __wasi_timestamp_t precision,
+                                 __wasi_timestamp_t* time);
+
+  __wasi_errno_t environ_get (char** environ, char* environ_buf);
+
+  __wasi_errno_t environ_sizes_get (
+                                    size_t* environ_count,
+                                    size_t* environ_buf_size);
+
+  __wasi_errno_t fd_prestat_get (__wasi_fd_t fd, __wasi_prestat_t* buf);
+
+  __wasi_errno_t fd_prestat_dir_name (
+                                      __wasi_fd_t fd,
+                                      char* path,
+                                      size_t path_len);
+
+  __wasi_errno_t fd_close (__wasi_fd_t fd);
+
+  __wasi_errno_t fd_datasync (__wasi_fd_t fd);
+
+  __wasi_errno_t fd_pread (
+                           __wasi_fd_t fd,
+                           const(__wasi_iovec_t)* iovs,
+                           size_t iovs_len,
+                           __wasi_filesize_t offset,
+                           size_t* nread);
+
+  __wasi_errno_t fd_pwrite (
+                            __wasi_fd_t fd,
+                            const(__wasi_ciovec_t)* iovs,
+                            size_t iovs_len,
+                            __wasi_filesize_t offset,
+                            size_t* nwritten);
+
+  __wasi_errno_t fd_read (
+                          __wasi_fd_t fd,
+                          const(__wasi_iovec_t)* iovs,
+                          size_t iovs_len,
+                          size_t* nread);
+
+  __wasi_errno_t fd_renumber (__wasi_fd_t from, __wasi_fd_t to);
+
+  __wasi_errno_t fd_seek (
+                          __wasi_fd_t fd,
+                          __wasi_filedelta_t offset,
+                          __wasi_whence_t whence,
+                          __wasi_filesize_t* newoffset);
+
+  __wasi_errno_t fd_tell (__wasi_fd_t fd, __wasi_filesize_t* newoffset);
+
+  __wasi_errno_t fd_fdstat_get (__wasi_fd_t fd, __wasi_fdstat_t* buf);
+
+  __wasi_errno_t fd_fdstat_set_flags (
+                                      __wasi_fd_t fd,
+                                      __wasi_fdflags_t flags);
+
+  __wasi_errno_t fd_fdstat_set_rights (
+                                       __wasi_fd_t fd,
+                                       __wasi_rights_t fs_rights_base,
+                                       __wasi_rights_t fs_rights_inheriting);
+
+  __wasi_errno_t fd_sync (__wasi_fd_t fd);
+
+  __wasi_errno_t fd_write (
+                           __wasi_fd_t fd,
+                           const(__wasi_ciovec_t)* iovs,
+                           size_t iovs_len,
+                           size_t* nwritten);
+
+  __wasi_errno_t fd_advise (
+                            __wasi_fd_t fd,
+                            __wasi_filesize_t offset,
+                            __wasi_filesize_t len,
+                            __wasi_advice_t advice);
+
+  __wasi_errno_t fd_allocate (
+                              __wasi_fd_t fd,
+                              __wasi_filesize_t offset,
+                              __wasi_filesize_t len);
+
+  __wasi_errno_t path_create_directory (
+                                        __wasi_fd_t fd,
+                                        const(char)* path,
+                                        size_t path_len);
+
+  __wasi_errno_t path_link (
+                            __wasi_fd_t old_fd,
+                            __wasi_lookupflags_t old_flags,
+                            const(char)* old_path,
+                            size_t old_path_len,
+                            __wasi_fd_t new_fd,
+                            const(char)* new_path,
+                            size_t new_path_len);
+
+  __wasi_errno_t path_open (
+                            __wasi_fd_t dirfd,
+                            __wasi_lookupflags_t dirflags,
+                            const(char)* path,
+                            size_t path_len,
+                            __wasi_oflags_t oflags,
+                            __wasi_rights_t fs_rights_base,
+                            __wasi_rights_t fs_rights_inheriting,
+                            __wasi_fdflags_t fs_flags,
+                            __wasi_fd_t* fd);
+
+  __wasi_errno_t fd_readdir (
+                             __wasi_fd_t fd,
+                             void* buf,
+                             size_t buf_len,
+                             __wasi_dircookie_t cookie,
+                             size_t* bufused);
+
+  __wasi_errno_t path_readlink (
+                                __wasi_fd_t fd,
+                                const(char)* path,
+                                size_t path_len,
+                                char* buf,
+                                size_t buf_len,
+                                size_t* bufused);
+
+  __wasi_errno_t path_rename (
+                              __wasi_fd_t old_fd,
+                              const(char)* old_path,
+                              size_t old_path_len,
+                              __wasi_fd_t new_fd,
+                              const(char)* new_path,
+                              size_t new_path_len);
+
+  __wasi_errno_t fd_filestat_get (__wasi_fd_t fd, __wasi_filestat_t* buf);
+
+  __wasi_errno_t fd_filestat_set_times (
+                                        __wasi_fd_t fd,
+                                        __wasi_timestamp_t st_atim,
+                                        __wasi_timestamp_t st_mtim,
+                                        __wasi_fstflags_t fstflags);
+
+  __wasi_errno_t fd_filestat_set_size (
+                                       __wasi_fd_t fd,
+                                       __wasi_filesize_t st_size);
+
+  __wasi_errno_t path_filestat_get (
+                                    __wasi_fd_t fd,
+                                    __wasi_lookupflags_t flags,
+                                    const(char)* path,
+                                    size_t path_len,
+                                    __wasi_filestat_t* buf);
+
+  __wasi_errno_t path_filestat_set_times (
+                                          __wasi_fd_t fd,
+                                          __wasi_lookupflags_t flags,
+                                          const(char)* path,
+                                          size_t path_len,
+                                          __wasi_timestamp_t st_atim,
+                                          __wasi_timestamp_t st_mtim,
+                                          __wasi_fstflags_t fstflags);
+
+  __wasi_errno_t path_symlink (
+                               const(char)* old_path,
+                               size_t old_path_len,
+                               __wasi_fd_t fd,
+                               const(char)* new_path,
+                               size_t new_path_len);
+
+  __wasi_errno_t path_unlink_file (
+                                   __wasi_fd_t fd,
+                                   const(char)* path,
+                                   size_t path_len);
+
+  __wasi_errno_t path_remove_directory (
+                                        __wasi_fd_t fd,
+                                        const(char)* path,
+                                        size_t path_len);
+
+  __wasi_errno_t poll_oneoff (
+                              const(__wasi_subscription_t)* in_,
+                              __wasi_event_t* out_,
+                              size_t nsubscriptions,
+                              size_t* nevents);
+
+  void proc_exit (__wasi_exitcode_t rval);
+
+  __wasi_errno_t proc_raise (__wasi_signal_t sig);
+
+  __wasi_errno_t random_get (void* buf, size_t buf_len);
+
+  __wasi_errno_t sock_recv (
+                            __wasi_fd_t sock,
+                            const(__wasi_iovec_t)* ri_data,
+                            size_t ri_data_len,
+                            __wasi_riflags_t ri_flags,
+                            size_t* ro_datalen,
+                            __wasi_roflags_t* ro_flags);
+
+  __wasi_errno_t sock_send (
+                            __wasi_fd_t sock,
+                            const(__wasi_ciovec_t)* si_data,
+                            size_t si_data_len,
+                            __wasi_siflags_t si_flags,
+                            size_t* so_datalen);
+
+  __wasi_errno_t sock_shutdown (__wasi_fd_t sock, __wasi_sdflags_t how);
+
+  __wasi_errno_t sched_yield ();
+}

--- a/src/core/sys/wasi/dirent.d
+++ b/src/core/sys/wasi/dirent.d
@@ -1,0 +1,82 @@
+/**
+ * D header file for WASI.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Sean Kelly,
+ Alex Rønne Petersn
+ * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ */
+
+/*          Copyright Sean Kelly 2005 - 2009.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.sys.wasi.dirent;
+
+private import core.sys.wasi.config;
+public import core.sys.wasi.sys.types; // for ino_t
+
+version (WebAssembly):
+extern (C):
+nothrow:
+@nogc:
+
+//
+// Required
+//
+/*
+  DIR
+
+  struct dirent
+  {
+  char[] d_name;
+  }
+
+  int     closedir(DIR*);
+  DIR*    opendir(const scope char*);
+  dirent* readdir(DIR*);
+  void    rewinddir(DIR*);
+*/
+
+enum
+{
+    DT_UNKNOWN  = 0,
+    DT_FIFO     = 1,
+    DT_CHR      = 2,
+    DT_DIR      = 4,
+    DT_BLK      = 6,
+    DT_REG      = 8,
+    DT_LNK      = 10,
+    DT_SOCK     = 12,
+    DT_WHT      = 14
+}
+
+struct dirent
+{
+    ino_t       d_ino;
+    ubyte       d_type;
+    char[256]   d_name = 0;
+}
+
+struct DIR
+{
+}
+
+int     closedir(DIR*);
+DIR*    opendir(const scope char*);
+//dirent* readdir(DIR*);
+void    rewinddir(DIR*);
+static if ( __USE_FILE_OFFSET64 )
+    {
+        dirent* readdir64(DIR*);
+        alias   readdir64 readdir;
+    }
+ else
+     {
+         dirent* readdir(DIR*);
+     }
+int readdir_r(DIR*, dirent*, dirent**);
+void   seekdir(DIR*, c_long);
+c_long telldir(DIR*);

--- a/src/core/sys/wasi/fcntl.d
+++ b/src/core/sys/wasi/fcntl.d
@@ -1,0 +1,159 @@
+/**
+ * D header file for WASI.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Sean Kelly, Alex Rønne Petersen
+ * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ */
+
+/*          Copyright Sean Kelly 2005 - 2009.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.sys.wasi.fcntl;
+
+version (WebAssembly) { version = WASI; }
+
+version (WASI):
+
+private import core.sys.wasi.config;
+private import core.stdc.stdint;
+public import core.sys.wasi.sys.types; // for off_t, mode_t
+public import core.sys.wasi.sys.stat;  // for S_IFMT, etc.
+
+extern (C):
+nothrow:
+@nogc:
+
+//
+// Required
+//
+/*
+  F_DUPFD
+  F_GETFD
+  F_SETFD
+  F_GETFL
+  F_SETFL
+  F_GETLK
+  F_SETLK
+  F_SETLKW
+  F_GETOWN
+  F_SETOWN
+
+  FD_CLOEXEC
+
+  F_RDLCK
+  F_UNLCK
+  F_WRLCK
+
+  O_CREAT
+  O_EXCL
+  O_NOCTTY
+  O_TRUNC
+
+  O_APPEND
+  O_DSYNC
+  O_NONBLOCK
+  O_RSYNC
+  O_SYNC
+
+  O_ACCMODE
+  O_RDONLY
+  O_RDWR
+  O_WRONLY
+
+  struct flock
+  {
+  short   l_type;
+  short   l_whence;
+  off_t   l_start;
+  off_t   l_len;
+  pid_t   l_pid;
+  }
+
+  int creat(const scope char*, mode_t);
+  int fcntl(int, int, ...);
+  int open(const scope char*, int, ...);
+*/
+enum {
+    O_CREAT         = 0x40,     // octal     0100
+    O_EXCL          = 0x80,     // octal     0200
+    O_NOCTTY        = 0x100,    // octal     0400
+    O_TRUNC         = 0x200,    // octal    01000
+
+    O_APPEND        = 0x400,    // octal    02000
+    O_NONBLOCK      = 0x800,    // octal    04000
+    O_DSYNC         = 0x1000,   // octal   010000
+    O_SYNC          = 0x101000, // octal 04010000
+    O_RSYNC         = O_SYNC,
+    O_DIRECTORY     = 0x10000,
+    O_NOFOLLOW      = 0x20000,
+    O_CLOEXEC       = 0x80000,
+
+    O_ASYNC         = 0x2000,
+    O_DIRECT        = 0x4000,
+    O_LARGEFILE     =      0,
+    O_NOATIME       = 0x40000,
+    O_PATH          = 0x200000,
+    O_TMPFILE       = 0x410000,
+    O_NDELAY        = O_NONBLOCK,
+    O_SEARCH        = O_PATH,
+    O_EXEC          = O_PATH,
+
+    O_ACCMODE       = (03|O_SEARCH),
+    O_RDONLY        = 00,
+    O_WRONLY        = 01,
+    O_RDWR          = 02,
+}
+enum {
+    F_DUPFD        = 0,
+    F_GETFD        = 1,
+    F_SETFD        = 2,
+    F_GETFL        = 3,
+    F_SETFL        = 4,
+    F_GETLK        = 5,
+    F_SETLK        = 6,
+    F_SETLKW       = 7,
+    F_SETOWN       = 8,
+    F_GETOWN       = 9,
+}
+enum {
+    F_RDLCK        = 0,
+    F_WRLCK        = 1,
+    F_UNLCK        = 2,
+}
+struct flock
+{
+    short   l_type;
+    short   l_whence;
+    off_t   l_start;
+    off_t   l_len;
+    pid_t   l_pid;
+}
+enum FD_CLOEXEC     = 1;
+int open(const scope char*, int, ...);
+
+enum AT_FDCWD = -100;
+
+//int creat(const scope char*, mode_t);
+int fcntl(int, int, ...);
+//int open(const scope char*, int, ...);
+
+// Generic Posix fallocate
+int posix_fallocate(int, off_t, off_t);
+
+//
+// Advisory Information (ADV)
+//
+/*
+  POSIX_FADV_NORMAL
+  POSIX_FADV_SEQUENTIAL
+  POSIX_FADV_RANDOM
+  POSIX_FADV_WILLNEED
+  POSIX_FADV_DONTNEED
+  POSIX_FADV_NOREUSE
+
+  int posix_fadvise(int, off_t, off_t, int);
+*/

--- a/src/core/sys/wasi/signal.d
+++ b/src/core/sys/wasi/signal.d
@@ -1,0 +1,224 @@
+module core.sys.wasi.signal;
+
+version (WebAssembly) {
+    version = WASI;
+}
+
+version (WASI):
+
+private import core.sys.wasi.config;
+public import core.stdc.signal;
+public import core.sys.wasi.sys.types;
+
+private alias void function(int) sigfn_t;
+private alias void function(int, siginfo_t*, void*) sigactfn_t;
+
+// nothrow versions
+nothrow @nogc
+{
+  private alias void function(int) sigfn_t2;
+  private alias void function(int, siginfo_t*, void*) sigactfn_t2;
+}
+
+enum
+  {
+    SIGEV_SIGNAL,
+    SIGEV_NONE,
+    SIGEV_THREAD
+  }
+
+union sigval
+{
+  int     sival_int;
+  void*   sival_ptr;
+}
+
+enum SIGHUP    = 1;
+enum SIGQUIT   = 3;
+enum SIGTRAP   = 5;
+enum SIGBUS    = 7;
+enum SIGKILL   = 9;
+enum SIGUSR1   = 10;
+enum SIGUSR2   = 12;
+enum SIGPIPE   = 13;
+enum SIGALRM   = 14;
+enum SIGCHLD   = 16;
+enum SIGCONT   = 17;
+enum SIGSTOP   = 18;
+enum SIGTSTP   = 19;
+enum SIGTTIN   = 20;
+enum SIGTTOU   = 21;
+enum SIGURG    = 22;
+enum SIGXCPU   = 23;
+enum SIGXFSZ   = 24;
+enum SIGVTALRM = 25;
+enum SIGPROF   = 26;
+enum SIGWINCH  = 27;
+enum SIGPOLL   = 28;
+enum SIGPWR    = 29;
+enum SIGSYS    = 30;
+
+
+struct sigaction_t
+{
+  static if ( true /* __USE_POSIX199309 */ )
+    {
+      union
+      {
+        sigfn_t     sa_handler;
+        sigactfn_t  sa_sigaction;
+      }
+    }
+  else
+    {
+      sigfn_t     sa_handler;
+    }
+  sigset_t        sa_mask;
+  int             sa_flags;
+
+  void function() sa_restorer;
+}
+
+    struct sigset_t
+    {
+        c_ulong[128/c_long.sizeof] __bits;
+    }
+
+    version (MIPS_Any)
+    {
+        enum SIG_BLOCK      = 1;
+        enum SIG_UNBLOCK    = 2;
+        enum SIG_SETMASK    = 3;
+    }
+    else
+    {
+        enum SIG_BLOCK      = 0;
+        enum SIG_UNBLOCK    = 1;
+        enum SIG_SETMASK    = 2;
+    }
+
+    struct siginfo_t
+    {
+        int si_signo;
+        version (MIPS_Any)  // __SI_SWAP_ERRNO_CODE
+        {
+            int si_code;
+            int si_errno;
+        }
+        else
+        {
+            int si_errno;
+            int si_code;
+        }
+        union __si_fields_t
+        {
+            char[128 - 2*int.sizeof - c_long.sizeof] __pad = 0;
+            struct __si_common_t
+            {
+                union __first_t
+                {
+                    struct __piduid_t
+                    {
+                        pid_t si_pid;
+                        uid_t si_uid;
+                    }
+                    __piduid_t __piduid;
+
+                    struct __timer_t
+                    {
+                        int si_timerid;
+                        int si_overrun;
+                    }
+                    __timer_t __timer;
+                }
+                __first_t __first;
+
+                union __second_t
+                {
+                    sigval si_value;
+                    struct __sigchld_t
+                    {
+                        int si_status;
+                        clock_t si_utime;
+                        clock_t si_stime;
+                    }
+                    __sigchld_t __sigchld;
+                }
+                __second_t __second;
+            }
+            __si_common_t __si_common;
+
+            struct __sigfault_t
+            {
+                void *si_addr;
+                short si_addr_lsb;
+                union __first_t
+                {
+                    struct __addr_bnd_t
+                    {
+                        void *si_lower;
+                        void *si_upper;
+                    }
+                    __addr_bnd_t __addr_bnd;
+                    uint si_pkey;
+                }
+                __first_t __first;
+            }
+            __sigfault_t __sigfault;
+
+            struct __sigpoll_t
+            {
+                c_long si_band;
+                int si_fd;
+            }
+            __sigpoll_t __sigpoll;
+
+            struct __sigsys_t
+            {
+                void *si_call_addr;
+                int si_syscall;
+                uint si_arch;
+            }
+            __sigsys_t __sigsys;
+        }
+        __si_fields_t __si_fields;
+    }
+
+    int kill(pid_t, int);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
+    int sigaddset(sigset_t*, int);
+    int sigdelset(sigset_t*, int);
+    int sigemptyset(sigset_t*);
+    int sigfillset(sigset_t*);
+    int sigismember(const scope sigset_t*, int);
+    int sigpending(sigset_t*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
+
+
+struct sigaltstack {
+  void *ss_sp;
+  int ss_flags;
+  size_t ss_size;
+}
+alias stack_t = sigaltstack;
+
+struct timespec {
+  time_t tv_sec;
+  ulong tv_nsec;
+}
+
+struct sigevent
+{
+  sigval sigev_value;
+  int sigev_signo;
+  int sigev_notify;
+  void function(sigval) sigev_notify_function;
+  pthread_attr_t *sigev_notify_attributes;
+  char[56 - 3 * c_long.sizeof] __pad = void;
+}
+
+int pthread_kill(pthread_t, int);
+int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
+int pthread_sigqueue(pthread_t, int, sigval);

--- a/src/core/sys/wasi/spawn.d
+++ b/src/core/sys/wasi/spawn.d
@@ -1,0 +1,26 @@
+module core.sys.wasi.spawn;
+
+version (WebAssembly) {
+  version = WASI;
+}
+
+version (WASI):
+
+import core.sys.wasi.sys.types;
+
+struct posix_spawnattr_t
+{
+    int __flags;
+    pid_t __pgrp;
+    sigset_t __def, __mask;
+    int __prio, __pol;
+    void *__fn;
+    char[64-(void *).sizeof] __pad;
+}
+
+struct posix_spawn_file_actions_t
+{
+    int[2] __pad0;
+    void *__actions;
+    int[16] __pad;
+}

--- a/src/core/sys/wasi/stdio.d
+++ b/src/core/sys/wasi/stdio.d
@@ -1,0 +1,161 @@
+/**
+ * D header file for WASI.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Sean Kelly
+ * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ */
+
+/*          Copyright Sean Kelly 2005 - 2009.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.sys.wasi.stdio;
+
+version (WebAssembly) {
+    version = WASI;
+}
+
+version (WASI):
+
+private import core.sys.wasi.config;
+public import core.stdc.stdio;
+public import core.sys.wasi.sys.types; // for off_t
+
+extern (C):
+
+nothrow:
+@nogc:
+
+//
+// Required (defined in core.stdc.stdio)
+//
+/*
+BUFSIZ
+_IOFBF
+_IOLBF
+_IONBF
+L_tmpnam
+SEEK_CUR
+SEEK_END
+SEEK_SET
+FILENAME_MAX
+FOPEN_MAX
+TMP_MAX
+EOF
+NULL
+stderr
+stdin
+stdout
+FILE
+fpos_t
+size_t
+
+void   clearerr(FILE*);
+int    fclose(FILE*);
+int    feof(FILE*);
+int    ferror(FILE*);
+int    fflush(FILE*);
+int    fgetc(FILE*);
+int    fgetpos(FILE*, fpos_t *);
+char*  fgets(char*, int, FILE*);
+FILE*  fopen(const scope char*, const scope char*);
+int    fprintf(FILE*, const scope char*, ...);
+int    fputc(int, FILE*);
+int    fputs(const scope char*, FILE*);
+size_t fread(void *, size_t, size_t, FILE*);
+FILE*  freopen(const scope char*, const scope char*, FILE*);
+int    fscanf(FILE*, const scope char*, ...);
+int    fseek(FILE*, c_long, int);
+int    fsetpos(FILE*, const scope fpos_t*);
+c_long ftell(FILE*);
+size_t fwrite(in void *, size_t, size_t, FILE*);
+int    getc(FILE*);
+int    getchar();
+char*  gets(char*);
+void   perror(const scope char*);
+int    printf(const scope char*, ...);
+int    putc(int, FILE*);
+int    putchar(int);
+int    puts(const scope char*);
+int    remove(const scope char*);
+int    rename(const scope char*, const scope char*);
+void   rewind(FILE*);
+int    scanf(const scope char*, ...);
+void   setbuf(FILE*, char*);
+int    setvbuf(FILE*, char*, int, size_t);
+int    snprintf(char*, size_t, const scope char*, ...);
+int    sprintf(char*, const scope char*, ...);
+int    sscanf(const scope char*, const scope char*, int ...);
+FILE*  tmpfile();
+char*  tmpnam(char*);
+int    ungetc(int, FILE*);
+int    vfprintf(FILE*, const scope char*, va_list);
+int    vfscanf(FILE*, const scope char*, va_list);
+int    vprintf(const scope char*, va_list);
+int    vscanf(const scope char*, va_list);
+int    vsnprintf(char*, size_t, const scope char*, va_list);
+int    vsprintf(char*, const scope char*, va_list);
+int    vsscanf(const scope char*, const scope char*, va_list arg);
+*/
+
+//
+// C Extension (CX)
+//
+/*
+L_ctermid
+
+char*  ctermid(char*);
+FILE*  fdopen(int, const scope char*);
+int    fileno(FILE*);
+int    fseeko(FILE*, off_t, int);
+off_t  ftello(FILE*);
+char*  gets(char*);
+int    pclose(FILE*);
+FILE*  popen(const scope char*, const scope char*);
+*/
+
+int   fseeko(FILE*, off_t, int);
+off_t ftello(FILE*);
+
+char*  ctermid(char*);
+FILE*  fdopen(int, const scope char*);
+int    fileno(FILE*);
+//int    fseeko(FILE*, off_t, int);
+//off_t  ftello(FILE*);
+char*  gets(char*);
+int    pclose(FILE*);
+FILE*  popen(const scope char*, const scope char*);
+
+
+//
+// Thread-Safe Functions (TSF)
+//
+/*
+void   flockfile(FILE*);
+int    ftrylockfile(FILE*);
+void   funlockfile(FILE*);
+int    getc_unlocked(FILE*);
+int    getchar_unlocked();
+int    putc_unlocked(int, FILE*);
+int    putchar_unlocked(int);
+*/
+
+//
+// XOpen (XSI)
+//
+/*
+P_tmpdir
+va_list (defined in core.stdc.stdarg)
+
+char*  tempnam(const scope char*, const scope char*);
+*/
+
+char*  tempnam(const scope char*, const scope char*);
+
+enum P_tmpdir  = "/tmp";
+
+ssize_t getdelim (char** lineptr, size_t* n, int delimiter, FILE* stream);
+ssize_t getline (char** lineptr, size_t* n, FILE* stream);

--- a/src/core/sys/wasi/sys/socket.d
+++ b/src/core/sys/wasi/sys/socket.d
@@ -1,0 +1,9 @@
+module core.sys.wasi.sys.socket;
+
+version (WebAssembly) {
+  version = WASI;
+}
+
+version (WASI):
+
+alias sa_family_t = ushort;

--- a/src/core/sys/wasi/sys/stat.d
+++ b/src/core/sys/wasi/sys/stat.d
@@ -1,0 +1,199 @@
+/**
+ * D header file for WASI.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Sean Kelly, Alex Rønne Petersen
+ * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ */
+
+/*          Copyright Sean Kelly 2005 - 2009.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.sys.wasi.sys.stat;
+
+private import core.sys.wasi.config;
+private import core.stdc.stdint;
+private import core.sys.wasi.time;     // for timespec
+public import core.sys.wasi.sys.types; // for off_t, mode_t
+
+version (WebAssembly)
+version = WASI;
+
+version (WASI):
+extern (C) nothrow @nogc:
+
+//
+// Required
+//
+/*
+  struct stat
+  {
+  dev_t   st_dev;
+  ino_t   st_ino;
+  mode_t  st_mode;
+  nlink_t st_nlink;
+  uid_t   st_uid;
+  gid_t   st_gid;
+  off_t   st_size;
+  time_t  st_atime;
+  time_t  st_mtime;
+  time_t  st_ctime;
+  }
+
+  S_IRWXU
+  S_IRUSR
+  S_IWUSR
+  S_IXUSR
+  S_IRWXG
+  S_IRGRP
+  S_IWGRP
+  S_IXGRP
+  S_IRWXO
+  S_IROTH
+  S_IWOTH
+  S_IXOTH
+  S_ISUID
+  S_ISGID
+  S_ISVTX
+
+  S_ISBLK(m)
+  S_ISCHR(m)
+  S_ISDIR(m)
+  S_ISFIFO(m)
+  S_ISREG(m)
+  S_ISLNK(m)
+  S_ISSOCK(m)
+
+  S_TYPEISMQ(buf)
+  S_TYPEISSEM(buf)
+  S_TYPEISSHM(buf)
+
+  int    chmod(const scope char*, mode_t);
+  int    fchmod(int, mode_t);
+  int    fstat(int, stat*);
+  int    lstat(const scope char*, stat*);
+  int    mkdir(const scope char*, mode_t);
+  int    mkfifo(const scope char*, mode_t);
+  int    stat(const scope char*, stat*);
+  mode_t umask(mode_t);
+*/
+
+alias __mode_t = uint;
+enum {
+    S_IRUSR    = 0x100, // octal 0400
+    S_IWUSR    = 0x080, // octal 0200
+    S_IXUSR    = 0x040, // octal 0100
+    S_IRWXU    = S_IRUSR | S_IWUSR | S_IXUSR,
+
+    S_IRGRP    = S_IRUSR >> 3,
+    S_IWGRP    = S_IWUSR >> 3,
+    S_IXGRP    = S_IXUSR >> 3,
+    S_IRWXG    = S_IRWXU >> 3,
+
+    S_IROTH    = S_IRGRP >> 3,
+    S_IWOTH    = S_IWGRP >> 3,
+    S_IXOTH    = S_IXGRP >> 3,
+    S_IRWXO    = S_IRWXG >> 3,
+
+    S_ISUID    = 0x800, // octal 04000
+    S_ISGID    = 0x400, // octal 02000
+    S_ISVTX    = 0x200, // octal 01000
+}
+struct stat_t {
+    dev_t st_dev;
+    ino_t st_ino;
+    nlink_t st_nlink;
+
+    mode_t st_mode;
+    uid_t st_uid;
+    gid_t st_gid;
+    uint    __pad0;
+    dev_t st_rdev;
+    off_t st_size;
+    blksize_t st_blksize;
+    blkcnt_t st_blocks;
+
+    timespec st_atim;
+    timespec st_mtim;
+    timespec st_ctim;
+    extern(D) @safe @property inout pure nothrow
+    {
+        ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+        ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+        ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+    }
+    long[3] __unused;
+}
+private
+    {
+        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        {
+            return ( mode & S_IFMT ) == mask;
+        }
+    }
+
+extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+
+int utimensat(int dirfd, const char *pathname,
+              ref const(timespec)[2] times, int flags);
+
+int    chmod(const scope char*, mode_t);
+int    fchmod(int, mode_t);
+//int    fstat(int, stat_t*);
+//int    lstat(const scope char*, stat_t*);
+int    mkdir(const scope char*, mode_t);
+int    mkfifo(const scope char*, mode_t);
+//int    stat(const scope char*, stat_t*);
+mode_t umask(mode_t);
+
+int stat(const scope char*, stat_t*);
+int fstat(int, stat_t*);
+int lstat(const scope char*, stat_t*);
+
+alias fstat fstat64;
+alias lstat lstat64;
+alias stat stat64;
+//
+// Typed Memory Objects (TYM)
+//
+/*
+  S_TYPEISTMO(buf)
+*/
+
+//
+// XOpen (XSI)
+//
+/*
+  S_IFMT
+  S_IFBLK
+  S_IFCHR
+  S_IFIFO
+  S_IFREG
+  S_IFDIR
+  S_IFLNK
+  S_IFSOCK
+
+  int mknod(in 3char*, mode_t, dev_t);
+*/
+
+enum {
+    S_IFMT     = 0xF000, // octal 0170000
+    S_IFBLK    = 0x6000, // octal 0060000
+    S_IFCHR    = 0x2000, // octal 0020000
+    S_IFIFO    = 0x1000, // octal 0010000
+    S_IFREG    = 0x8000, // octal 0100000
+    S_IFDIR    = 0x4000, // octal 0040000
+    S_IFLNK    = 0xA000, // octal 0120000
+    S_IFSOCK   = 0xC000, // octal 0140000
+}
+
+int mknod(const scope char*, mode_t, dev_t);

--- a/src/core/sys/wasi/sys/statvfs.d
+++ b/src/core/sys/wasi/sys/statvfs.d
@@ -1,0 +1,42 @@
+/++
+    D header file correspoding to sys/statvfs.h.
+
+    Copyright: Copyright 2012 -
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Robert Klotzner and $(HTTP jmdavisprog.com, Jonathan M Davis)
+    Standards: $(HTTP http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_statvfs.h.html,
+                      The Open Group Base Specifications Issue 7 IEEE Std 1003.1, 2018 Edition)
+ +/
+module core.sys.wasi.sys.statvfs;
+private import core.stdc.config;
+private import core.sys.wasi.config;
+public import core.sys.wasi.sys.types;
+
+version (WebAssembly):
+extern (C) :
+nothrow:
+@nogc:
+
+    struct statvfs_t
+    {
+        c_ulong f_bsize;
+        c_ulong f_frsize;
+        fsblkcnt_t f_blocks;
+        fsblkcnt_t f_bfree;
+        fsblkcnt_t f_bavail;
+        fsfilcnt_t f_files;
+        fsfilcnt_t f_ffree;
+        fsfilcnt_t f_favail;
+        c_ulong f_fsid;
+        c_ulong f_flag;
+        c_ulong f_namemax;
+    }
+
+    enum FFlag
+    {
+        ST_RDONLY = 1,        /* Mount read-only.  */
+        ST_NOSUID = 2
+    }
+
+    int statvfs (const char * file, statvfs_t* buf);
+    int fstatvfs (int fildes, statvfs_t *buf) @trusted;

--- a/src/core/sys/wasi/sys/time.d
+++ b/src/core/sys/wasi/sys/time.d
@@ -1,0 +1,62 @@
+/**
+ * D header file for WASI.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Sean Kelly, Alex Rønne Petersen
+ * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ */
+
+/*          Copyright Sean Kelly 2005 - 2009.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.sys.wasi.sys.time;
+
+version (WebAssembly) {
+  version = WASI;
+}
+
+version (WASI):
+
+private import core.sys.wasi.config;
+public import core.sys.wasi.sys.types;  // for time_t, suseconds_t
+// public import core.sys.wasi.sys.select; // for fd_set, FD_CLR() FD_ISSET() FD_SET() FD_ZERO() FD_SETSIZE, select()
+
+extern (C) nothrow @nogc:
+
+//
+// XOpen (XSI)
+//
+/*
+struct timeval
+{
+    time_t      tv_sec;
+    suseconds_t tv_usec;
+}
+
+struct itimerval
+{
+    timeval it_interval;
+    timeval it_value;
+}
+
+ITIMER_REAL
+ITIMER_VIRTUAL
+ITIMER_PROF
+
+int getitimer(int, itimerval*);
+int gettimeofday(timeval*, void*);
+int select(int, fd_set*, fd_set*, fd_set*, timeval*); (defined in core.sys.posix.sys.signal)
+int setitimer(int, const scope itimerval*, itimerval*);
+int utimes(const scope char*, ref const(timeval)[2]); // LEGACY
+*/
+
+struct timeval
+{
+    time_t      tv_sec;
+    suseconds_t tv_usec;
+}
+int gettimeofday(timeval*, void*);
+int utimes(const scope char*, ref const(timeval)[2]);

--- a/src/core/sys/wasi/sys/types.d
+++ b/src/core/sys/wasi/sys/types.d
@@ -1,0 +1,59 @@
+module core.sys.wasi.sys.types;
+
+version (WebAssembly) {
+  version = WASI;
+}
+
+version (WASI):
+
+private import core.stdc.stdint;
+public import core.stdc.stddef;
+import core.sys.wasi.config;
+
+alias ubyte pthread_attr_t;
+alias ubyte pthread_mutex_t;
+alias ubyte mtx_t;
+alias ubyte pthread_cond_t;
+alias ubyte cnd_t;
+alias ubyte pthread_rwlock_t;
+alias ubyte pthread_barrier_t;
+alias int pthread_once_t;
+alias uint pthread_key_t;
+alias int pthread_spinlock_t;
+struct pthread_mutexattr_t { uint __attr; } ;
+struct pthread_condattr_t { uint __attr; } ;
+struct pthread_barrierattr_t{ uint __attr; } ;
+struct pthread_rwlockattr_t{ uint[2] __attr; } ;
+
+alias long      blksize_t;
+alias ulong     nlink_t;
+alias long      dev_t;
+alias long      blkcnt_t;
+alias ulong     ino_t;
+alias long      off_t;
+alias int       _Addr;
+alias int       pid_t;
+alias uint      uid_t;
+alias uint      gid_t;
+alias long      time_t;
+alias long      clock_t;
+alias ulong     pthread_t;
+alias _Addr     ssize_t;
+alias sigset_t = ubyte;
+
+static if ( __USE_FILE_OFFSET64 )
+  {
+    alias ulong     fsblkcnt_t;
+    alias ulong     fsfilcnt_t;
+  }
+ else
+   {
+     alias ulong_t   fsblkcnt_t;
+     alias ulong_t   fsfilcnt_t;
+   }
+alias uint mode_t;
+alias uint id_t;
+version (D_X32)
+alias long susseconds_t;
+ else
+   alias c_long suseconds_t;

--- a/src/core/sys/wasi/sys/un.d
+++ b/src/core/sys/wasi/sys/un.d
@@ -1,0 +1,29 @@
+module core.sys.wasi.sys.un;
+
+version (WebAssembly) {
+  version = WASI;
+}
+
+version (WASI):
+
+extern(C):
+
+public import core.sys.wasi.sys.socket: sa_family_t;
+
+//
+// Required
+//
+/*
+struct sockaddr_un
+{
+    sa_family_t sun_family;
+    char        sa_data[];
+}
+
+sa_family_t    // From core.sys.posix.sys.socket
+*/
+
+struct sockaddr_un {
+    sa_family_t sun_family;
+    char[108] sun_path;
+}

--- a/src/core/sys/wasi/time.d
+++ b/src/core/sys/wasi/time.d
@@ -1,0 +1,87 @@
+module core.sys.wasi.time;
+
+version (WebAssembly) {
+    version = WASI;
+}
+
+version (WASI):
+
+private import core.sys.wasi.config;
+public import core.stdc.time;
+public import core.sys.wasi.sys.types;
+public import core.sys.wasi.signal; // for sigevent
+
+extern (C):
+nothrow:
+@nogc:
+
+//
+// Required (defined in core.stdc.time)
+//
+/*
+  char* asctime(in tm*);
+  clock_t clock();
+  char* ctime(in time_t*);
+  double difftime(time_t, time_t);
+  tm* gmtime(in time_t*);
+  tm* localtime(in time_t*);
+  time_t mktime(tm*);
+  size_t strftime(char*, size_t, in char*, in tm*);
+  time_t time(time_t*);
+*/
+
+time_t timegm(tm*);
+
+// TODO: use wasi.core defines here instead of magic vals
+enum CLOCK_MONOTONIC = 1;
+
+alias int clockid_t;
+alias void* timer_t;
+
+struct timespec
+{
+  time_t  tv_sec;
+  c_long  tv_nsec;
+}
+
+struct itimerspec
+{
+    timespec it_interval;
+    timespec it_value;
+}
+
+enum TIMER_ABSTIME = 1;
+
+enum CLOCK_REALTIME = 0;
+enum CLOCK_PROCESS_CPUTIME_ID = 2;
+enum CLOCK_THREAD_CPUTIME_ID = 3;
+enum CLOCK_REALTIME_COARSE = 5;
+enum CLOCK_BOOTTIME = 7;
+enum CLOCK_REALTIME_ALARM = 8;
+enum CLOCK_BOOTTIME_ALARM = 9;
+enum CLOCK_SGI_CYCLE = 10;
+enum CLOCK_TAI = 11;
+
+int nanosleep(const scope timespec*, timespec*);
+
+int clock_getres(clockid_t, timespec*);
+int clock_gettime(clockid_t, timespec*);
+int clock_nanosleep(clockid_t, int, const scope timespec*, timespec*);
+int clock_getcpuclockid(pid_t, clockid_t *);
+
+int timer_create(clockid_t, sigevent*, timer_t*);
+int timer_delete(timer_t);
+int timer_gettime(timer_t, itimerspec*);
+int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
+int timer_getoverrun(timer_t);
+
+char* asctime_r(const scope tm*, char*);
+char* ctime_r(const scope time_t*, char*);
+tm*   gmtime_r(const scope time_t*, tm*);
+tm*   localtime_r(const scope time_t*, tm*);
+
+extern __gshared int daylight;
+extern __gshared c_long timezone;
+
+tm*   getdate(const scope char*);
+char* strptime(const scope char*, const scope char*, tm*);

--- a/src/core/sys/wasi/ucontext.d
+++ b/src/core/sys/wasi/ucontext.d
@@ -1,0 +1,43 @@
+module core.sys.wasi.ucontext;
+
+version (WebAssembly) {
+  version = WASI;
+}
+
+version (WASI):
+
+public import core.sys.wasi.signal; // for sigset_t, stack_t
+private import core.stdc.stdint : uintptr_t;
+
+extern (C):
+nothrow:
+@nogc:
+
+//
+// XOpen (XSI)
+//
+/*
+mcontext_t
+
+struct ucontext_t
+{
+    ucontext_t* uc_link;
+    sigset_t    uc_sigmask;
+    stack_t     uc_stack;
+    mcontext_t  uc_mcontext;
+}
+*/
+
+struct mcontext_t
+{
+    ulong[32] __space;
+}
+struct ucontext_t
+{
+    ulong uc_flags;
+    ucontext_t *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    sigset_t uc_sigmask;
+    ulong[64] __fpregs_mem;
+}

--- a/src/core/sys/wasi/unistd.d
+++ b/src/core/sys/wasi/unistd.d
@@ -1,0 +1,379 @@
+/**
+ * D header file for WASI.
+ *
+ * Copyright: Copyright Sebastiaan Koppe 2019 - 2020.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Sebastiaan Koppe
+ * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ */
+
+/*        Copyright Sebastiaan Koppe 2019 - 2020.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.sys.wasi.unistd;
+
+version (WebAssembly) { version = WASI; }
+
+version (WASI):
+
+private import core.sys.wasi.config;
+private import core.stdc.stddef;
+// public import core.sys.wasi.inttypes;  // for intptr_t
+public import core.sys.wasi.sys.types; // for ssize_t, uid_t, gid_t, off_t, pid_t, useconds_t
+
+extern (C):
+nothrow:
+@nogc:
+
+enum STDIN_FILENO  = 0;
+enum STDOUT_FILENO = 1;
+enum STDERR_FILENO = 2;
+
+extern __gshared char*   optarg;
+extern __gshared int     optind;
+extern __gshared int     opterr;
+extern __gshared int     optopt;
+
+int     access(const scope char*, int);
+uint    alarm(uint) @trusted;
+int     chdir(const scope char*);
+int     chown(const scope char*, uid_t, gid_t);
+int     close(int) @trusted;
+size_t  confstr(int, char*, size_t);
+int     dup(int) @trusted;
+int     dup2(int, int) @trusted;
+int     execl(const scope char*, const scope char*, ...);
+int     execle(const scope char*, const scope char*, ...);
+int     execlp(const scope char*, const scope char*, ...);
+int     execv(const scope char*, const scope char**);
+int     execve(const scope char*, const scope char**, const scope char**);
+int     execvp(const scope char*, const scope char**);
+void    _exit(int) @trusted;
+int     fchown(int, uid_t, gid_t) @trusted;
+pid_t   fork() @trusted;
+c_long  fpathconf(int, int) @trusted;
+//int     ftruncate(int, off_t);
+char*   getcwd(char*, size_t);
+gid_t   getegid() @trusted;
+uid_t   geteuid() @trusted;
+gid_t   getgid() @trusted;
+int     getgroups(int, gid_t *);
+int     gethostname(char*, size_t);
+char*   getlogin() @trusted;
+int     getlogin_r(char*, size_t);
+int     getopt(int, const scope char**, const scope char*);
+pid_t   getpgrp() @trusted;
+pid_t   getpid() @trusted;
+pid_t   getppid() @trusted;
+uid_t   getuid() @trusted;
+int     isatty(int) @trusted;
+int     link(const scope char*, const scope char*);
+//off_t   lseek(int, off_t, int);
+c_long  pathconf(const scope char*, int);
+int     pause() @trusted;
+int     pipe(ref int[2]) @trusted;
+ssize_t read(int, void*, size_t);
+ssize_t readlink(const scope char*, char*, size_t);
+int     rmdir(const scope char*);
+int     setegid(gid_t) @trusted;
+int     seteuid(uid_t) @trusted;
+int     setgid(gid_t) @trusted;
+int     setgroups(size_t, const scope gid_t*) @trusted;
+int     setpgid(pid_t, pid_t) @trusted;
+pid_t   setsid() @trusted;
+int     setuid(uid_t) @trusted;
+uint    sleep(uint) @trusted;
+int     symlink(const scope char*, const scope char*);
+c_long  sysconf(int) @trusted;
+pid_t   tcgetpgrp(int) @trusted;
+int     tcsetpgrp(int, pid_t) @trusted;
+char*   ttyname(int) @trusted;
+int     ttyname_r(int, char*, size_t);
+int     unlink(const scope char*);
+ssize_t write(int, const scope void*, size_t);
+
+int ftruncate(int, off_t) @trusted;
+off_t lseek(int, off_t, int) @trusted;
+alias ftruncate ftruncate64;
+alias lseek lseek64;
+enum F_OK       = 0;
+enum R_OK       = 4;
+enum W_OK       = 2;
+enum X_OK       = 1;
+
+enum F_ULOCK    = 0;
+enum F_LOCK     = 1;
+enum F_TLOCK    = 2;
+enum F_TEST     = 3;
+
+enum
+    {
+        _CS_PATH,
+        _CS_POSIX_V6_WIDTH_RESTRICTED_ENVS,
+        _CS_GNU_LIBC_VERSION,
+        _CS_GNU_LIBPTHREAD_VERSION,
+        _CS_POSIX_V5_WIDTH_RESTRICTED_ENVS,
+        _CS_POSIX_V7_WIDTH_RESTRICTED_ENVS,
+
+        _CS_POSIX_V6_ILP32_OFF32_CFLAGS = 1116,
+        _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+        _CS_POSIX_V6_ILP32_OFF32_LIBS,
+        _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+        _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+        _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+        _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+        _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+        _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+        _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+        _CS_POSIX_V6_LP64_OFF64_LIBS,
+        _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+        _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+        _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+        _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+        _CS_POSIX_V7_ILP32_OFF32_LIBS,
+        _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+        _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+        _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+        _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+        _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+        _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+        _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+        _CS_POSIX_V7_LP64_OFF64_LIBS,
+        _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+        _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+        _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+        _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+        _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+        _CS_V6_ENV,
+        _CS_V7_ENV
+    }
+
+enum
+    {
+        _PC_LINK_MAX,
+        _PC_MAX_CANON,
+        _PC_MAX_INPUT,
+        _PC_NAME_MAX,
+        _PC_PATH_MAX,
+        _PC_PIPE_BUF,
+        _PC_CHOWN_RESTRICTED,
+        _PC_NO_TRUNC,
+        _PC_VDISABLE,
+        _PC_SYNC_IO,
+        _PC_ASYNC_IO,
+        _PC_PRIO_IO,
+        _PC_SOCK_MAXBUF,
+        _PC_FILESIZEBITS,
+        _PC_REC_INCR_XFER_SIZE,
+        _PC_REC_MAX_XFER_SIZE,
+        _PC_REC_MIN_XFER_SIZE,
+        _PC_REC_XFER_ALIGN,
+        _PC_ALLOC_SIZE_MIN,
+        _PC_SYMLINK_MAX,
+        _PC_2_SYMLINKS
+    }
+
+enum
+    {
+        _SC_ARG_MAX,
+        _SC_CHILD_MAX,
+        _SC_CLK_TCK,
+        _SC_NGROUPS_MAX,
+        _SC_OPEN_MAX,
+        _SC_STREAM_MAX,
+        _SC_TZNAME_MAX,
+        _SC_JOB_CONTROL,
+        _SC_SAVED_IDS,
+        _SC_REALTIME_SIGNALS,
+        _SC_PRIORITY_SCHEDULING,
+        _SC_TIMERS,
+        _SC_ASYNCHRONOUS_IO,
+        _SC_PRIORITIZED_IO,
+        _SC_SYNCHRONIZED_IO,
+        _SC_FSYNC,
+        _SC_MAPPED_FILES,
+        _SC_MEMLOCK,
+        _SC_MEMLOCK_RANGE,
+        _SC_MEMORY_PROTECTION,
+        _SC_MESSAGE_PASSING,
+        _SC_SEMAPHORES,
+        _SC_SHARED_MEMORY_OBJECTS,
+        _SC_AIO_LISTIO_MAX,
+        _SC_AIO_MAX,
+        _SC_AIO_PRIO_DELTA_MAX,
+        _SC_DELAYTIMER_MAX,
+        _SC_MQ_OPEN_MAX,
+        _SC_MQ_PRIO_MAX,
+        _SC_VERSION,
+        _SC_PAGE_SIZE,
+        _SC_PAGESIZE = _SC_PAGE_SIZE,
+        _SC_RTSIG_MAX,
+        _SC_SEM_NSEMS_MAX,
+        _SC_SEM_VALUE_MAX,
+        _SC_SIGQUEUE_MAX,
+        _SC_TIMER_MAX,
+        _SC_BC_BASE_MAX,
+        _SC_BC_DIM_MAX,
+        _SC_BC_SCALE_MAX,
+        _SC_BC_STRING_MAX,
+        _SC_COLL_WEIGHTS_MAX,
+
+        _SC_EXPR_NEST_MAX = 42,
+        _SC_LINE_MAX,
+        _SC_RE_DUP_MAX,
+
+        _SC_2_VERSION = 46,
+        _SC_2_C_BIND,
+        _SC_2_C_DEV,
+        _SC_2_FORT_DEV,
+        _SC_2_FORT_RUN,
+        _SC_2_SW_DEV,
+        _SC_2_LOCALEDEF,
+
+        _SC_UIO_MAXIOV = 60,
+        _SC_IOV_MAX = _SC_UIO_MAXIOV,
+
+        _SC_THREADS = 67,
+        _SC_THREAD_SAFE_FUNCTIONS,
+        _SC_GETGR_R_SIZE_MAX,
+        _SC_GETPW_R_SIZE_MAX,
+        _SC_LOGIN_NAME_MAX,
+        _SC_TTY_NAME_MAX,
+        _SC_THREAD_DESTRUCTOR_ITERATIONS,
+        _SC_THREAD_KEYS_MAX,
+        _SC_THREAD_STACK_MIN,
+        _SC_THREAD_THREADS_MAX,
+        _SC_THREAD_ATTR_STACKADDR,
+        _SC_THREAD_ATTR_STACKSIZE,
+        _SC_THREAD_PRIORITY_SCHEDULING,
+        _SC_THREAD_PRIO_INHERIT,
+        _SC_THREAD_PRIO_PROTECT,
+        _SC_THREAD_PROCESS_SHARED,
+
+        _SC_NPROCESSORS_CONF,
+        _SC_NPROCESSORS_ONLN,
+        _SC_PHYS_PAGES,
+        _SC_AVPHYS_PAGES,
+        _SC_ATEXIT_MAX,
+        _SC_PASS_MAX,
+
+        _SC_XOPEN_VERSION,
+        _SC_XOPEN_XCU_VERSION,
+        _SC_XOPEN_UNIX,
+        _SC_XOPEN_CRYPT,
+        _SC_XOPEN_ENH_I18N,
+        _SC_XOPEN_SHM,
+
+        _SC_2_CHAR_TERM,
+        _SC_2_UPE = 97,
+
+        _SC_XOPEN_XPG2,
+        _SC_XOPEN_XPG3,
+        _SC_XOPEN_XPG4,
+
+        _SC_NZERO = 109,
+
+        _SC_XBS5_ILP32_OFF32 = 125,
+        _SC_XBS5_ILP32_OFFBIG,
+        _SC_XBS5_LP64_OFF64,
+        _SC_XBS5_LPBIG_OFFBIG,
+
+        _SC_XOPEN_LEGACY,
+        _SC_XOPEN_REALTIME,
+        _SC_XOPEN_REALTIME_THREADS,
+
+        _SC_ADVISORY_INFO,
+        _SC_BARRIERS,
+        _SC_CLOCK_SELECTION = 137,
+        _SC_CPUTIME,
+        _SC_THREAD_CPUTIME,
+        _SC_MONOTONIC_CLOCK = 149,
+        _SC_READER_WRITER_LOCKS = 153,
+        _SC_SPIN_LOCKS,
+        _SC_REGEXP,
+        _SC_SHELL = 157,
+        _SC_SPAWN = 159,
+        _SC_SPORADIC_SERVER,
+        _SC_THREAD_SPORADIC_SERVER,
+        _SC_TIMEOUTS = 164,
+        _SC_TYPED_MEMORY_OBJECTS,
+        _SC_2_PBS = 168,
+        _SC_2_PBS_ACCOUNTING,
+        _SC_2_PBS_LOCATE,
+        _SC_2_PBS_MESSAGE,
+        _SC_2_PBS_TRACK,
+        _SC_SYMLOOP_MAX,
+        _SC_STREAMS,
+        _SC_2_PBS_CHECKPOINT,
+
+        _SC_V6_ILP32_OFF32,
+        _SC_V6_ILP32_OFFBIG,
+        _SC_V6_LP64_OFF64,
+        _SC_V6_LPBIG_OFFBIG,
+
+        _SC_HOST_NAME_MAX,
+        _SC_TRACE,
+        _SC_TRACE_EVENT_FILTER,
+        _SC_TRACE_INHERIT,
+        _SC_TRACE_LOG,
+
+        _SC_IPV6 = 235,
+        _SC_RAW_SOCKETS,
+        _SC_V7_ILP32_OFF32,
+        _SC_V7_ILP32_OFFBIG,
+        _SC_V7_LP64_OFF64,
+        _SC_V7_LPBIG_OFFBIG,
+        _SC_SS_REPL_MAX,
+        _SC_TRACE_EVENT_NAME_MAX,
+        _SC_TRACE_NAME_MAX,
+        _SC_TRACE_SYS_MAX,
+        _SC_TRACE_USER_EVENT_MAX,
+        _SC_XOPEN_STREAMS,
+        _SC_THREAD_ROBUST_PRIO_INHERIT,
+        _SC_THREAD_ROBUST_PRIO_PROTECT
+    }
+//
+// File Synchronization (FSC)
+//
+/*
+  int fsync(int);
+*/
+
+int fsync(int) @trusted;
+
+//
+// XOpen (XSI)
+//
+/*
+  char*      crypt(const scope char*, const scope char*);
+  char*      ctermid(char*);
+  void       encrypt(ref char[64], int);
+  int        fchdir(int);
+  c_long     gethostid();
+  pid_t      getpgid(pid_t);
+  pid_t      getsid(pid_t);
+  char*      getwd(char*); // LEGACY
+  int        lchown(const scope char*, uid_t, gid_t);
+  int        lockf(int, int, off_t);
+  int        nice(int);
+  ssize_t    pread(int, void*, size_t, off_t);
+  ssize_t    pwrite(int, const scope void*, size_t, off_t);
+  pid_t      setpgrp();
+  int        setregid(gid_t, gid_t);
+  int        setreuid(uid_t, uid_t);
+  void       swab(const scope void*, void*, ssize_t);
+  void       sync();
+  int        truncate(const scope char*, off_t);
+  useconds_t ualarm(useconds_t, useconds_t);
+  int        usleep(useconds_t);
+  pid_t      vfork();
+*/
+
+int fchdir(int) @trusted;
+int lockf(int, int, off_t);
+alias lockf lockf64;

--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -11,6 +11,8 @@
 
 module core.thread.fiber;
 
+version (WebAssembly) {} else:
+
 import core.thread.osthread;
 
 version (LDC)

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -12,6 +12,23 @@
 
 module core.thread.osthread;
 
+version (WebAssembly) {
+    // NOTE: This is defined in this file, but because we version the whole out and the gc
+    // relies on it we put it here. Really, it should go somewhere else entirely
+    /**
+     * Indicates whether an address has been marked by the GC.
+     */
+    enum IsMarked : int
+    {
+        no, /// Address is not marked.
+        yes, /// Address is marked.
+        unknown, /// Address is not managed by the GC.
+    }
+    extern (C) void thread_init() @nogc {}
+    extern (C) void thread_joinAll() {}
+    extern (C) void thread_term() @nogc {}
+} else:
+
 import core.time;
 import core.exception : onOutOfMemoryError;
 
@@ -2689,6 +2706,10 @@ else
                 asm pure nothrow @nogc { (store ~ " $29, %0") : "=m" (sp); }
                 asm pure nothrow @nogc { ".set at"; }
             }
+            else version (WebAssembly)
+            {
+                // TODO: noop
+            }
             else
             {
                 static assert(false, "Architecture not supported.");
@@ -3895,6 +3916,9 @@ version (Windows)
 else
 version (Posix)
     alias ThreadID = pthread_t;
+ else
+   version (WebAssembly)
+     alias ThreadID = pthread_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 // lowlovel threading support

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -92,6 +92,10 @@ else version (Posix)
 import core.sys.posix.time;
 import core.sys.posix.sys.time;
 }
+else version (WebAssembly)
+{
+import core.sys.wasi.core;
+}
 
 version (OSX)
     version = Darwin;
@@ -349,6 +353,12 @@ else version (Solaris) enum ClockType
     processCPUTime = 4,
     second = 6,
     threadCPUTime = 7,
+}
+else version (WebAssembly) enum ClockType
+{
+    normal = 0,
+    // processCPUTime = 4,
+    // threadCPUTime = 7
 }
 else
 {
@@ -2093,6 +2103,9 @@ struct MonoTimeImpl(ClockType clockType)
     {
         enum clockArg = _posixClock(clockType);
     }
+    else version (WebAssembly)
+    {
+    }
     else
         static assert(0, "Unsupported platform");
 
@@ -2157,6 +2170,22 @@ struct MonoTimeImpl(ClockType clockType)
             return MonoTimeImpl(convClockFreq(ts.tv_sec * 1_000_000_000L + ts.tv_nsec,
                                               1_000_000_000L,
                                               ticksPerSecond));
+        } else version (WebAssembly) {
+            enum maxLag = 0; // The amount of time that the implementation may wait additionally to coalesce with other events.
+          __wasi_clockid_t getClockId() {
+            with(ClockType) final switch (clockType) {
+                  case normal: return __WASI_CLOCK_MONOTONIC;
+                  // case processCPUTime: return __WASI_CLOCK_PROCESS_CPUTIME_ID;
+                  // case threadCPUTime: return __WASI_CLOCK_THREAD_CPUTIME_ID;
+              }
+          }
+          __wasi_timestamp_t time;
+          __wasi_clockid_t clockId = getClockId();
+          if (clock_time_get(clockId, maxLag, &time) != __WASI_ESUCCESS) {
+            import core.internal.abort : abort;
+            abort("Call to wasi_unstable.clock_time_get failed");
+          }
+          return MonoTimeImpl(time);
         }
     }
 
@@ -2551,6 +2580,16 @@ extern(C) void _d_initMonoTime()
                 }
             }
         }
+    } else version (WebAssembly) {
+      foreach (i, typeStr; __traits(allMembers, ClockType))
+      {
+        mixin("enum type = ClockType."~typeStr~";");
+        __wasi_timestamp_t res;
+        import core.internal.abort;
+        if (__WASI_ESUCCESS != clock_res_get(type, &res))
+          abort("Failed to call clock_res_get with clock "~typeStr);
+        tps[i] = res;
+      }
     }
 }
 
@@ -2569,6 +2608,9 @@ unittest
 
     static bool clockSupported(ClockType c)
     {
+      version (WebAssembly) {
+        return true;
+      } else {
         // Skip unsupported clocks on older linux kernels, assume that only
         // CLOCK_MONOTONIC and CLOCK_REALTIME exist, as that is the lowest
         // common denominator supported by all versions of Linux pre-2.6.12.
@@ -2576,7 +2618,7 @@ unittest
             return c == ClockType.normal || c == ClockType.precise;
         else
             return c != ClockType.second; // second doesn't work with MonoTimeImpl
-
+        }
     }
 
     foreach (typeStr; __traits(allMembers, ClockType))
@@ -2849,6 +2891,14 @@ struct TickDuration
             }
             else
                 ticksPerSec = 1_000_000;
+        }
+        else version (WebAssembly) {
+            __wasi_timestamp_t resolution;
+            if (clock_res_get(__WASI_CLOCK_MONOTONIC, &resolution) != __WASI_ESUCCESS) {
+                import core.internal.abort : abort;
+                abort("Call to wasi_unstable.clock_res_get failed");
+            }
+            ticksPerSec = 1_000_000_000 / resolution;
         }
 
         if (ticksPerSec != 0)
@@ -3242,6 +3292,7 @@ struct TickDuration
         t2 /= 2.1;
         assert(t1 > t2);
 
+        version (WebAssembly) {} else
         _assertThrown!TimeException(t2 /= 0);
 
         foreach (T; AliasSeq!(const TickDuration, immutable TickDuration))
@@ -3322,6 +3373,7 @@ struct TickDuration
             assertApprox(t2 / 2.0, t1 - tol, t1 + tol);
             assert(t2 / 2.1 < t1);
 
+            version (WebAssembly) {} else
             _assertThrown!TimeException(t2 / 0);
         }
     }
@@ -3415,6 +3467,15 @@ struct TickDuration
                 return TickDuration(tv.tv_sec * TickDuration.ticksPerSec +
                                     tv.tv_usec * TickDuration.ticksPerSec / 1000 / 1000);
             }
+        } else version (WebAssembly)
+        {
+            enum maxLag = 0; // The amount of time that the implementation may wait additionally to coalesce with other events.
+            __wasi_timestamp_t time;
+            if (clock_time_get(__WASI_CLOCK_MONOTONIC, maxLag, &time) != __WASI_ESUCCESS) {
+                import core.internal.abort : abort;
+                abort("Call to wasi_unstable.clock_time_get failed");
+            }
+            return TickDuration(time);
         }
     }
 
@@ -3624,17 +3685,20 @@ public:
 
         foreach (sign; [1, -1])
         {
+            version (WebAssembly) {} else
             _assertThrown!TimeException(from!"msecs"(1000 * sign));
 
             assert(FracSec.from!"msecs"(1 * sign) == FracSec(10_000 * sign));
             assert(FracSec.from!"msecs"(999 * sign) == FracSec(9_990_000 * sign));
 
+            version (WebAssembly) {} else
             _assertThrown!TimeException(from!"usecs"(1_000_000 * sign));
 
             assert(FracSec.from!"usecs"(1 * sign) == FracSec(10 * sign));
             assert(FracSec.from!"usecs"(999 * sign) == FracSec(9990 * sign));
             assert(FracSec.from!"usecs"(999_999 * sign) == FracSec(9999_990 * sign));
 
+            version (WebAssembly) {} else
             _assertThrown!TimeException(from!"hnsecs"(10_000_000 * sign));
 
             assert(FracSec.from!"hnsecs"(1 * sign) == FracSec(1 * sign));
@@ -3712,8 +3776,12 @@ public:
                 throw new AssertError("unittest failure", __FILE__, line);
         }
 
-        _assertThrown!TimeException(test(-1000));
-        _assertThrown!TimeException(test(1000));
+        version (WebAssembly) {}
+        else
+        {
+            _assertThrown!TimeException(test(-1000));
+            _assertThrown!TimeException(test(1000));
+        }
 
         test(0, FracSec(0));
 
@@ -3771,8 +3839,12 @@ public:
                 throw new AssertError("unittest failure", __FILE__, line);
         }
 
-        _assertThrown!TimeException(test(-1_000_000));
-        _assertThrown!TimeException(test(1_000_000));
+        version (WebAssembly) {}
+        else
+        {
+            _assertThrown!TimeException(test(-1_000_000));
+            _assertThrown!TimeException(test(1_000_000));
+        }
 
         test(0, FracSec(0));
 
@@ -3830,8 +3902,12 @@ public:
                 throw new AssertError("unittest failure", __FILE__, line);
         }
 
-        _assertThrown!TimeException(test(-10_000_000));
-        _assertThrown!TimeException(test(10_000_000));
+        version (WebAssembly) {}
+        else
+        {
+            _assertThrown!TimeException(test(-10_000_000));
+            _assertThrown!TimeException(test(10_000_000));
+        }
 
         test(0, FracSec(0));
 
@@ -3891,8 +3967,12 @@ public:
                 throw new AssertError("unittest failure", __FILE__, line);
         }
 
-        _assertThrown!TimeException(test(-1_000_000_000));
-        _assertThrown!TimeException(test(1_000_000_000));
+        version (WebAssembly) {}
+        else
+        {
+            _assertThrown!TimeException(test(-1_000_000_000));
+            _assertThrown!TimeException(test(1_000_000_000));
+        }
 
         test(0, FracSec(0));
 
@@ -4546,6 +4626,7 @@ version (unittest) void _assertThrown(T : Throwable = Exception, E)
     }
 }
 
+version (WebAssembly) {} else
 unittest
 {
 

--- a/src/gc/bits.d
+++ b/src/gc/bits.d
@@ -15,8 +15,8 @@ module gc.bits;
 
 
 import core.bitop;
-import core.stdc.string;
-import core.stdc.stdlib;
+import core.stdc.string : memset, memcpy;
+import core.stdc.stdlib : free, calloc;
 import core.exception : onOutOfMemoryError;
 
 // use version gcbitsSingleBitOperation to disable optimizations that use
@@ -88,6 +88,13 @@ struct GCBits
     // return non-zero if bit already set
     size_t setLocked(size_t i) nothrow
     {
+      version (WebAssembly) {
+        const pos = i >> BITS_SHIFT;
+        const mask = BITS_1 << (i & BITS_MASK);
+        auto val = *(data + pos) & mask;
+        *(data + pos) = *(data + pos) | mask;
+        return (val & mask) != 0;
+      } else
         version (GNU)
         {
             import gcc.builtins;

--- a/src/gc/os.d
+++ b/src/gc/os.d
@@ -14,7 +14,30 @@
 module gc.os;
 
 
-version (Windows)
+version (WebAssembly)
+{
+   nothrow:
+   private __gshared void* wasmFreeList = null;
+   __gshared void* wasmStart = null;
+   enum WasmPageSize = 64*1024;
+
+   // returns amount of 64Kb pages
+   pragma(LDC_intrinsic, "llvm.wasm.memory.size.i32")
+      private int _wasmMemorySize(int memIndex) @safe pure nothrow @nogc;
+
+   pragma(inline, true) auto wasmMemorySize() @safe pure nothrow @nogc {
+      return _wasmMemorySize(0);
+   }
+
+   // adjust memory according to delta (64Kb pages)
+   pragma(LDC_intrinsic, "llvm.wasm.memory.grow.i32")
+      int _wasmMemoryGrow(int memIndex, int delta) @safe pure nothrow @nogc;
+
+   pragma(inline, true)
+      auto wasmMemoryGrow(int delta) @safe pure nothrow @nogc {
+      return _wasmMemoryGrow(0, delta);
+   }
+} else version (Windows)
 {
     import core.sys.windows.winbase : GetCurrentThreadId, VirtualAlloc, VirtualFree;
     import core.sys.windows.winnt : MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_READWRITE;
@@ -130,7 +153,7 @@ else static if (is(typeof(malloc))) // else version (GC_Use_Alloc_Malloc)
     //       after PAGESIZE bytes used by the GC.
 
 
-    import gc.gc;
+    // import gc.gc;
 
 
     const size_t PAGE_MASK = PAGESIZE - 1;
@@ -151,10 +174,109 @@ else static if (is(typeof(malloc))) // else version (GC_Use_Alloc_Malloc)
         return 0;
     }
 }
-else
+else version (WebAssembly)
 {
-    static assert(false, "No supported allocation methods available.");
-}
+    // NOTE: a very simple allocater with a coalescing freelist
+    private __gshared void* freelist = null;
+    struct FreeListItem {
+        size_t bytes;
+        FreeListItem* next;
+    }
+    private void push(void* base, size_t nbytes) nothrow @trusted {
+        // insert the item and maintains a sorted freelist
+        // returns the item before the insertion (or the first)
+        static FreeListItem* insert(FreeListItem* item) nothrow @trusted {
+            // if it should be first
+            if (item < freelist) {
+                item.next = cast(FreeListItem*)freelist;
+                freelist = cast(void*)item;
+                return item;
+            }
+            // insert sorted on address
+            auto p = cast(FreeListItem*)freelist;
+            for(;;) {
+                if (!p.next) {
+                    p.next = item;
+                    return p;
+                }
+                if (item < p.next) {
+                    item.next = p.next;
+                    p.next = item;
+                    return p;
+                }
+                p = p.next;
+            }
+            assert(0);
+        }
+        static void coalesce(FreeListItem* item) nothrow @trusted {
+            for (;;) {
+                if (!item.next)
+                    return;
+                if (cast(void*)item + item.bytes !is item.next)
+                    return;
+                item.bytes += item.next.bytes;
+                item.next = item.next.next;
+            }
+        }
+        auto item = cast(FreeListItem*)(base);
+        item.bytes = nbytes;
+        if (freelist is null) {
+            freelist = cast(void*)item;
+            item.next = null;
+        } else {
+            coalesce(insert(item));
+        }
+    }
+    private void[] pop(size_t nbytes) nothrow @trusted {
+        if (freelist is null)
+            return [];
+        auto prev = cast(FreeListItem**)&freelist;
+        auto p = cast(FreeListItem*)freelist;
+        for (;;) {
+            if (p.bytes >= nbytes) {
+                auto mem = (cast(void*)p)[0..nbytes];
+                if (p.bytes - nbytes > 0) {
+                    auto newItem = cast(FreeListItem*)(cast(void*)p + nbytes);
+                    newItem.bytes = p.bytes - nbytes;
+                    (*prev) = newItem;
+                } else
+                    (*prev) = p.next;
+                return mem;
+            }
+            if (p.next is null)
+                return [];
+            prev = &p.next;
+            p = p.next;
+        }
+    }
+
+    void *os_mem_map(size_t nbytes) nothrow @trusted
+    {
+        if (wasmStart is null)
+            wasmStart = cast(void*)(wasmMemorySize() * WasmPageSize);
+        auto mem = pop(nbytes);
+        if (mem == null || mem.length == 0) {
+            int pages = cast(int)((nbytes + WasmPageSize - 1) >> 16);
+            auto currentPages = wasmMemoryGrow(0);
+            cast(void)wasmMemoryGrow(pages);
+            auto addr = cast(void*)(wasmStart + currentPages * WasmPageSize);
+            mem = addr[0 .. pages * WasmPageSize];
+        } else {
+        }
+        if (mem.length > nbytes) {
+            push(&mem[0] + nbytes, mem.length - nbytes);
+        }
+        return &mem[0];
+    }
+
+    int os_mem_unmap(void *base, size_t nbytes) nothrow @safe
+    {
+        push(base, nbytes);
+        return 0;
+    }
+
+} else
+      static assert(false, "No supported allocation methods available.");
 
 /**
    Check for any kind of memory pressure.

--- a/src/ldc/eh_wasm.d
+++ b/src/ldc/eh_wasm.d
@@ -1,0 +1,15 @@
+/**
+ * This module implements the runtime-part of LDC exceptions
+ * on Windows, based on the MSVC++ runtime.
+ */
+module ldc.eh_wasm;
+
+version (WebAssembly):
+
+extern (C) void _d_throw_exception(Throwable t) {
+  assert(0, t.msg);
+}
+
+extern (C) void _Unwind_Resume(void*) {
+  assert(0, "No unwind support");
+}

--- a/src/rt/config.d
+++ b/src/rt/config.d
@@ -58,7 +58,10 @@ template rt_options()
 }
 
 import core.stdc.ctype : toupper;
-import core.stdc.stdlib : getenv;
+version (WebAssembly) {
+  // while it is possible to emulate getenv with wasi, I forgo that at this point
+} else
+    import core.stdc.stdlib : getenv;
 import core.stdc.string : strlen;
 
 extern extern(C) string[] rt_args() @nogc nothrow;
@@ -97,6 +100,7 @@ string rt_configOption(string opt, scope rt_configCallBack dg = null, bool rever
 
 string rt_cmdlineOption(string opt, scope rt_configCallBack dg) @nogc nothrow
 {
+  version (WebAssembly) {} else
     if (rt_cmdline_enabled!())
     {
         foreach (a; rt_args)
@@ -115,6 +119,9 @@ string rt_cmdlineOption(string opt, scope rt_configCallBack dg) @nogc nothrow
 
 string rt_envvarsOption(string opt, scope rt_configCallBack dg) @nogc nothrow
 {
+  version (WebAssembly) {
+    return null;
+  } else {
     if (rt_envvars_enabled!())
     {
         if (opt.length >= 32)
@@ -135,6 +142,7 @@ string rt_envvarsOption(string opt, scope rt_configCallBack dg) @nogc nothrow
         }
     }
     return null;
+  }
 }
 
 string rt_linkOption(string opt, scope rt_configCallBack dg) @nogc nothrow

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -386,6 +386,12 @@ extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
             totalArgsLength += arg.length;
         }
     }
+    else version (WebAssembly)
+    {
+      // TODO: what can we do here?
+      char[][] args;
+      size_t totalArgsLength = 0;
+    }
     else
         static assert(0);
 

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -14,7 +14,7 @@ module rt.lifetime;
 
 import core.memory;
 debug(PRINTF) import core.stdc.stdio;
-static import rt.tlsgc;
+version (WebAssembly) {} else static import rt.tlsgc;
 version (LDC) import ldc.attributes;
 
 alias BlkInfo = GC.BlkInfo;
@@ -570,7 +570,8 @@ static ~this()
 }
 
 
-// we expect this to be called with the lock in place
+version (WebAssembly) {} else
+// // we expect this to be called with the lock in place
 void processGCMarks(BlkInfo* cache, scope rt.tlsgc.IsMarkedDg isMarked) nothrow
 {
     // called after the mark routine to eliminate block cache data when it
@@ -2201,6 +2202,8 @@ extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c)
     return x;
 }
 
+// NOTE: fails in wasm because of exceptions
+version (WebAssembly) {} else
 unittest
 {
     import core.exception : UnicodeException;
@@ -2553,6 +2556,8 @@ unittest
     test(1024 * 1024);
 }
 
+// NOTE: fails in wasm because of exceptions
+version (WebAssembly) {} else
 unittest
 {
     import core.exception;
@@ -2846,7 +2851,9 @@ unittest
     }
 }
 
-// test class finalizers exception handling
+// NOTE: catching expections not supported in wasm
+// // test class finalizers exception handling
+version (WebAssembly) {} else
 unittest
 {
     bool test(E)()
@@ -2881,7 +2888,9 @@ unittest
     assert(!test!InvalidMemoryOperationError);
 }
 
+// NOTE: catching expections not supported in wasm
 // test struct finalizers exception handling
+version (WebAssembly) {} else
 debug(SENTINEL) {} else
 unittest
 {

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -868,6 +868,8 @@ void runModuleFuncsRev(alias getfp)(const(immutable(ModuleInfo)*)[] modules)
     }
 }
 
+// NOTE: fails in wasm because of exceptions
+version (WebAssembly) {} else
 unittest
 {
     static void assertThrown(T : Throwable, E)(lazy E expr, string msg)

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -218,6 +218,25 @@ else version (Posix)
         pthread_mutex_unlock(mtx) && assert(0);
     }
 }
+ else version (WebAssembly) {
+   struct Mutex {}
+ @nogc:
+   void initMutex(Mutex* mtx)
+   {
+   }
+
+   void destroyMutex(Mutex* mtx)
+   {
+   }
+
+   void lockMutex(Mutex* mtx)
+   {
+   }
+
+   void unlockMutex(Mutex* mtx)
+   {
+   }
+ }
 else
 {
     static assert(0, "Unsupported platform");

--- a/src/rt/profilegc.d
+++ b/src/rt/profilegc.d
@@ -94,8 +94,7 @@ static ~this()
 {
     if (newCounts.length)
     {
-        synchronized
-        {
+        version (WebAssembly) { // NOTE: synchronized blocks call critsecsize in ldc which is unknown for wasm
             foreach (name, entry; newCounts)
             {
                 if (!(name in globalNewCounts))
@@ -103,6 +102,18 @@ static ~this()
 
                 globalNewCounts[name].count += entry.count;
                 globalNewCounts[name].size += entry.size;
+            }
+        } else {
+            synchronized
+            {
+                foreach (name, entry; newCounts)
+                {
+                    if (!(name in globalNewCounts))
+                        globalNewCounts[name] = Entry.init;
+
+                    globalNewCounts[name].count += entry.count;
+                    globalNewCounts[name].size += entry.size;
+                }
             }
         }
         newCounts.reset();

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -53,7 +53,9 @@ else version (CRuntime_Bionic)
     public import rt.sections_android;
 else version (CRuntime_UClibc)
     public import rt.sections_elf_shared;
-else
+ else version (WebAssembly) {
+   // uses legacy linked list defined in rt.sections_ldc
+ } else
     static assert(0, "unimplemented");
 
 import rt.deh, rt.minfo;

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -11,6 +11,7 @@
 module rt.sections_elf_shared;
 
 version (CRuntime_Glibc) enum SharedELF = true;
+else version (WebAssembly) enum SharedELF = false; // TODO: needs to be WASI
 else version (CRuntime_Musl) enum SharedELF = true;
 else version (FreeBSD) enum SharedELF = true;
 else version (NetBSD) enum SharedELF = true;

--- a/src/rt/tlsgc.d
+++ b/src/rt/tlsgc.d
@@ -76,6 +76,7 @@ alias int delegate(void* addr) nothrow IsMarkedDg;
  */
 void processGCMarks(void* data, scope IsMarkedDg dg) nothrow
 {
+    version (WebAssembly) {} else //NOTE: do nothing on wasm. has no tls yet
     // do module specific sweeping
     rt.lifetime.processGCMarks(*(cast(Data*)data).blockInfoCache, dg);
 }

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -340,7 +340,7 @@ private void trace_times(FILE* fplog, Symbol*[] psymbols)
 
 private void trace_init()
 {
-    synchronized        // protects gtrace_inited
+    static void impl()
     {
         if (!gtrace_inited)
         {
@@ -368,6 +368,10 @@ private void trace_init()
             }
         }
     }
+    version (WebAssembly)
+        impl();
+    else
+        synchronized { impl(); }        // protects gtrace_inited
 }
 
 /////////////////////////////////
@@ -391,7 +395,7 @@ static ~this()
         stack_freelist = n;
     }
 
-    synchronized        // protects groot
+    static void impl()
     {
         // Merge thread local root into global groot
 
@@ -446,6 +450,10 @@ static ~this()
             mergeSymbol(&groot, root);
         }
     }
+    version (WebAssembly)
+        impl();
+    else
+        synchronized { impl(); }        // protects groot
 
     // Free the memory for the thread local symbol table (root)
     static void freeSymbol(Symbol* s)

--- a/src/rt/util/container/array.d
+++ b/src/rt/util/container/array.d
@@ -208,6 +208,8 @@ unittest
     assert(cnt == 0);
 }
 
+// NOTE: fails in wasm because of exceptions
+version (WebAssembly) {} else
 unittest
 {
     import core.exception;

--- a/src/rt/util/container/hashtab.d
+++ b/src/rt/util/container/hashtab.d
@@ -306,6 +306,8 @@ unittest
     assert(cnt == 0);
 }
 
+// NOTE: fails in wasm because of exceptions
+version (WebAssembly) {} else
 unittest
 {
     import core.exception;

--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -55,6 +55,18 @@ struct Rand48
             rng_state = mach_absolute_time();
             popFront();
         }
+        else version (WebAssembly)
+          {
+            import core.sys.wasi.core;
+            // TODO: this precision is just guessed... maybe first get with __wasi_clock_res_get
+            enum precision = 10000;
+            __wasi_timestamp_t time;
+            if (clock_time_get(__WASI_CLOCK_MONOTONIC, precision, &time) != __WASI_ESUCCESS) {
+              import core.internal.abort : abort;
+              abort("Call to wasi_unstable.clock_time_get failed");
+            }
+            rng_state = time;
+        }
         else
         {
             // Fallback to libc timestamp in seconds.

--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -96,3 +96,28 @@ shared static this()
 void main()
 {
 }
+
+// pragma(msg, "emit _start");
+// import ldc.attributes;
+// import core.sys.wasi.core;
+// extern (C) {
+//   pragma(mangle, "_d_run_main")
+//     int _d_run_main(int argc, char **argv, void* mainFunc);
+
+//   pragma(mangle, "_Dmain")
+//     int _Dmain(char[][] args);
+
+//   pragma(mangle, "main")
+//     int main(int argc, char **argv)
+//     {
+//       pragma(LDC_profile_instr, false);
+//       return _d_run_main(argc, argv, &_Dmain);
+//     }
+
+//   void __wasm_call_ctors();
+//   pragma(mangle, "_start")
+//     export void _start() {
+//     __wasm_call_ctors();
+//     proc_exit(main(0, null));
+//   }
+// }


### PR DESCRIPTION
In wasm, a struct that wraps a single value is treated differently than just that single value by itself in the calling convention. This was causing issues when functions such as `_aaLen` would be called with an `Impl*` value, which was then trying to be re-interpreted as an `AA`, meaning that the function would get garbage input.

This PR removes the `struct AA` definition, since it was just a wrapper around a single value, and thus fixes these issues.